### PR TITLE
[noup] CODEOWNERS: fix the list of users

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # precedence.
 
 # Root folder
-*      @krish2718 @jukkar @rado17 @rlubos @sachinthegreen
+*      @jukkar @krish2718 @rlubos


### PR DESCRIPTION
The CODEOWNERS file had users not really active in upstream so remove them.