### PR TITLE
Feature/dpp support

### DIFF
--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -2014,6 +2014,96 @@ out:
 
 #endif /* CONFIG_AP */
 
+int wpa_drv_zep_dpp_listen(void *priv, bool enable)
+{
+	struct zep_drv_if_ctx *if_ctx = NULL;
+	const struct zep_wpa_supp_dev_ops *dev_ops;
+	int ret = -1;
+
+	if ((!priv)) {
+		wpa_printf(MSG_ERROR, "%s: Invalid params", __func__);
+		goto out;
+	}
+
+	if_ctx = priv;
+	dev_ops = get_dev_ops(if_ctx->dev_ctx);
+
+	if (!dev_ops || !dev_ops->dpp_listen) {
+		wpa_printf(MSG_ERROR, "%s: dpp_listen op not supported", __func__);
+		goto out;
+	}
+
+	ret = dev_ops->dpp_listen(if_ctx->dev_priv, enable);
+	if (ret) {
+		wpa_printf(MSG_ERROR, "%s: dpp_listen op failed", __func__);
+		goto out;
+	}
+
+out:
+	return ret;
+
+}
+
+int wpa_drv_zep_remain_on_channel(void *priv, unsigned int freq,
+				  unsigned int duration)
+{
+	struct zep_drv_if_ctx *if_ctx = NULL;
+	const struct zep_wpa_supp_dev_ops *dev_ops = NULL;
+	int ret	= -1;
+
+	if (!priv) {
+		wpa_printf(MSG_ERROR, "%s: Invalid handle", __func__);
+		goto out;
+	}
+
+	if_ctx = priv;
+	dev_ops = get_dev_ops(if_ctx->dev_ctx);
+
+	if (!dev_ops || !dev_ops->remain_on_channel) {
+		wpa_printf(MSG_ERROR, "%s: remain_on_channel op not supported", __func__);
+		goto out;
+	}
+
+	ret = dev_ops->remain_on_channel(if_ctx->dev_priv, freq, duration);
+	if (ret) {
+		wpa_printf(MSG_ERROR, "%s: dpp_listen op failed", __func__);
+		goto out;
+	}
+
+out:
+	return ret;
+}
+
+int wpa_drv_zep_cancel_remain_on_channel(void *priv)
+{
+	struct zep_drv_if_ctx *if_ctx = NULL;
+	const struct zep_wpa_supp_dev_ops *dev_ops = NULL;
+	int ret	= -1;
+
+	if (!priv) {
+		wpa_printf(MSG_ERROR, "%s: Invalid handle", __func__);
+		goto out;
+	}
+
+	if_ctx = priv;
+	dev_ops = get_dev_ops(if_ctx->dev_ctx);
+
+	if (!dev_ops || !dev_ops->cancel_remain_on_channel) {
+		wpa_printf(MSG_ERROR, "%s: cancel_remain_on_channel op not supported", __func__);
+		goto out;
+	}
+
+	ret = dev_ops->cancel_remain_on_channel(if_ctx->dev_priv);
+	if (ret) {
+		wpa_printf(MSG_ERROR, "%s: dpp_listen op failed", __func__);
+		goto out;
+	}
+
+out:
+	return ret;
+}
+
+
 const struct wpa_driver_ops wpa_driver_zep_ops = {
 	.name = "zephyr",
 	.desc = "Zephyr wpa_supplicant driver",
@@ -2049,4 +2139,7 @@ const struct wpa_driver_ops wpa_driver_zep_ops = {
 	.sta_disassoc = wpa_drv_zep_sta_disassoc,
 	.sta_remove = wpa_drv_zep_sta_remove,
 #endif /* CONFIG_AP */
+	.dpp_listen = wpa_drv_zep_dpp_listen,
+	.remain_on_channel = wpa_drv_zep_remain_on_channel,
+	.cancel_remain_on_channel = wpa_drv_zep_cancel_remain_on_channel,
 };

--- a/src/drivers/driver_zephyr.h
+++ b/src/drivers/driver_zephyr.h
@@ -255,6 +255,10 @@ struct zep_wpa_supp_dev_ops {
 
 	int (*register_mgmt_frame)(void *if_priv, u16 frame_type,
 			size_t match_len, const u8 *match);
+
+	int (*dpp_listen)(void *priv, bool enable);
+	int (*remain_on_channel)(void *priv, unsigned int freq, unsigned int duration);
+	int (*cancel_remain_on_channel)(void *priv);
 };
 
 #endif /* DRIVER_ZEPHYR_H */

--- a/wpa_supplicant/config_none.c
+++ b/wpa_supplicant/config_none.c
@@ -30,6 +30,7 @@ struct wpa_config * wpa_config_read(const char *name, struct wpa_config *cfgp)
 	if (config == NULL)
 		return NULL;
 	/* TODO: fill in configuration data */
+	config->dpp_config_processing = 2;
 	return config;
 }
 

--- a/wpa_supplicant/ctrl_iface_zephyr.c
+++ b/wpa_supplicant/ctrl_iface_zephyr.c
@@ -73,7 +73,7 @@ static void wpa_supplicant_ctrl_iface_send(struct wpa_supplicant *wpa_s,
 		if (level >= dst->debug_level) {
 			memcpy(&msg.msg, buf, len);
 			msg.msg_len = len;
-			if (send(dst->sock, &msg, sizeof(msg), 0) < 0) {
+			if (send(dst->sock, &msg, len + 4, 0) < 0) {
 				wpa_printf(MSG_ERROR,
 					   "sendto(CTRL_IFACE monitor): %s",
 					   strerror(errno));

--- a/wpa_supplicant/dpp_supplicant.c
+++ b/wpa_supplicant/dpp_supplicant.c
@@ -534,8 +534,13 @@ static void wpas_dpp_tx_status(struct wpa_supplicant *wpa_s,
 		 * allow new authentication exchanges to be started. */
 		eloop_cancel_timeout(wpas_dpp_auth_conf_wait_timeout, wpa_s,
 				     NULL);
+#ifdef __ZEPHYR__
+		eloop_register_timeout(5, 0, wpas_dpp_auth_conf_wait_timeout,
+				       wpa_s, NULL);
+#else
 		eloop_register_timeout(1, 0, wpas_dpp_auth_conf_wait_timeout,
 				       wpa_s, NULL);
+#endif
 	}
 
 	if (!is_broadcast_ether_addr(dst) && auth->waiting_auth_resp &&
@@ -4005,8 +4010,13 @@ static void wpas_dpp_chirp_tx_status(struct wpa_supplicant *wpa_s,
 	}
 
 	wpa_printf(MSG_DEBUG, "DPP: Chirp send completed - wait for response");
+#ifdef __ZEPHYR__
+	if (eloop_register_timeout(5, 0, wpas_dpp_chirp_timeout,
+				   wpa_s, NULL) < 0)
+#else
 	if (eloop_register_timeout(2, 0, wpas_dpp_chirp_timeout,
 				   wpa_s, NULL) < 0)
+#endif
 		wpas_dpp_chirp_stop(wpa_s);
 }
 


### PR DESCRIPTION
[toup] dpp: add zephyr own timeout for dpp response timeout
    
    For some MCUs in zephyr that has lite CPU, hard code 1s or 2s may be
    not enough for SHA384 and SHA512 crypto calculation.
    
    So extend DPP wait for reponse timeout to 5s.

[toup] config: add dpp_config_processing
    
    Add dpp_config_processing 2, which means
    report received configuration to an external program, generate
    a network profile internally, try to connect to the created
    profile automatically.

[toup] zephyr: fix wpa_msg always use fixed msg size
    
    wpa_cli_open_connection create a mon_sock_pair to monitor hostap events.
    wpa_msg send msgs always with fixed size, 256 bytes for now.
    And wpa_cli_recv_pending receive msg through k_pipe_get by spair_read,
    which has, eg. 4KB queue size.
    
    That means if hostap eloop send more than 16 msgs, the socket pair will
    be full and block. Thus eloop cannot read socket pair and will be forever
    blocked. This case happens easy in DPP case as it has many wpa_msg INFO.
    
    Fix it by read msg header with variable length first,
    and then read whole msg.
    This will make more use of mon_sock_pair queue size.