### PR TITLE
[toup] zephyr: Fix build error and warning of zephyr

### DIFF
--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -335,8 +335,10 @@ static inline void WPA_PUT_LE64(u8 *a, u64 val)
 #ifndef ETH_HLEN
 #define ETH_HLEN 14
 #endif
+#ifndef __ZEPHYR__
 #ifndef IFNAMSIZ
 #define IFNAMSIZ 16
+#endif
 #endif
 #ifndef ETH_P_ALL
 #define ETH_P_ALL 0x0003
@@ -578,11 +580,6 @@ size_t int_array_len(const int *a);
 void int_array_concat(int **res, const int *a);
 void int_array_sort_unique(int *a);
 void int_array_add_unique(int **res, int a);
-
-#ifdef __ZEPHYR__
-char *inet_ntoa(struct in_addr in);
-int inet_pton(sa_family_t family, const char *src, void *dst);
-#endif
 
 #if !defined(ARRAY_SIZE)
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))


### PR DESCRIPTION
Fix build error that IFNAMSIZ redefined in zephyr and unknown type name 'sa_family_t', and fix the build warning of 'struct in_addr' declared inside parameter list will not be visible outside of this definition or declaration.