### PR TITLE
Feature/wpa cli cmd resp

### DIFF
--- a/wpa_supplicant/wpa_cli_zephyr.c
+++ b/wpa_supplicant/wpa_cli_zephyr.c
@@ -90,6 +90,11 @@ static int wpa_ctrl_command_resp(struct wpa_ctrl *ctrl, const char *cmd, char *r
 	return _wpa_ctrl_command(ctrl, cmd, 0, resp);
 }
 
+int zephyr_wpa_cli_cmd_resp(const char *cmd, char *resp)
+{
+	return _wpa_ctrl_command(ctrl_conn, cmd, 1, resp);
+}
+
 static void wpa_cli_close_connection(struct wpa_supplicant *wpa_s)
 {
 	int ret;

--- a/wpa_supplicant/wpa_cli_zephyr.c
+++ b/wpa_supplicant/wpa_cli_zephyr.c
@@ -68,10 +68,14 @@ static int _wpa_ctrl_command(struct wpa_ctrl *ctrl, const char *cmd, int print, 
 		return -1;
 	}
 
-	if (resp && len > 1) {
-		/* Remove the LF */
-		os_memcpy(resp, buf, len - 1);
-		resp[len - 1] = '\0';
+	if (resp && len > 0) {
+		os_memcpy(resp, buf, len);
+		if (len > 1 && resp[len - 1] == '\n') {
+			/* Remove the LF */
+			resp[len - 1] = '\0';
+		} else {
+			resp[len] = '\0';
+		}
 		if (strncmp(resp, "FAIL", 4) == 0)
 			return -3;
 	}

--- a/wpa_supplicant/wpa_cli_zephyr.h
+++ b/wpa_supplicant/wpa_cli_zephyr.h
@@ -30,6 +30,7 @@ int zephyr_wpa_ctrl_init(void *wpa_s);
 void zephyr_wpa_ctrl_deinit(void *wpa_s);
 int zephyr_wpa_ctrl_zephyr_cmd(int argc, const char *argv[]);
 int zephyr_wpa_cli_cmd_v(const char *fmt, ...);
+int zephyr_wpa_cli_cmd_resp(const char *cmd, char *resp);
 
 int z_wpa_ctrl_add_network(struct add_network_resp *resp);
 int z_wpa_ctrl_signal_poll(struct signal_poll_resp *resp);


### PR DESCRIPTION
[toup] zephyr: parse wpa_cli cmd resp without LF
    
    Some wpa_cli command responses end with LF, but some not.
    eg. DPP command responses are "1".
    
    So remove only LF when the 2nd last character is LF.
    
    Signed-off-by: Fengming Ye <frank.ye@nxp.com>

[toup] zephyr: add wpa_cli command with response
    
    Add wpa_cli command with response, in case some commands need to
    get response.
    eg. DPP commands print response info like bootstrap uri and added
    configurator id, bootstrap id, etc.
    But we want to parse them in L2 mgmt runtime function call instead of
    on console log.
    
    Signed-off-by: Fengming Ye <frank.ye@nxp.com>