### PR TITLE
[noup] zephyr: use MSG_INFO level for wpa_cli command response print

### DIFF
--- a/wpa_supplicant/wpa_cli_zephyr.c
+++ b/wpa_supplicant/wpa_cli_zephyr.c
@@ -83,7 +83,7 @@ static int _wpa_ctrl_command(struct wpa_ctrl *ctrl, const char *cmd, int print, 
 	if (print) {
 		buf[len] = '\0';
 		if (buf[0] != '\0')
-			wpa_printf(MSG_DEBUG, "%s", buf);
+			wpa_printf(MSG_INFO, "%s", buf);
 	}
 
 	return 0;


### PR DESCRIPTION
wpa_cli command with interactive means to show response info on console.
In this case it is better to use MSG_INFO level to print instead of
MSG_DEBUG level. As MSG_DEBUG level is for debug cases, but wpa_cli
response print is normal use case.