### PR TITLE
[nxp noup] zephyr: Fix memory leak in supplicant

### DIFF
--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -60,8 +60,9 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!ies) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d Failed to alloc %d bytes\n",
-					  __func__, __LINE__, data->auth.ies_len);
+					  "%s:%d EVENT_AUTH %u Failed to alloc ies %d bytes\n",
+					  __func__, __LINE__, event, data->auth.ies_len);
+					os_free(msg.data);
 					return;
 				}
 
@@ -76,8 +77,9 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!frame) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d Failed to alloc %d bytes\n",
-					  __func__, __LINE__, data->rx_mgmt.frame_len);
+					  "%s:%d EVENT_RX_MGMT %u Failed to alloc frame %d bytes\n",
+					  __func__, __LINE__, event, data->rx_mgmt.frame_len);
+					os_free(msg.data);
 					return;
 				}
 
@@ -93,8 +95,9 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!frame) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d Failed to alloc %d bytes\n",
-					  __func__, __LINE__, data->tx_status.data_len);
+					  "%s:%d EVENT_TX_STATUS %u Failed to alloc frame %d bytes\n",
+					  __func__, __LINE__, event, data->tx_status.data_len);
+					os_free(msg.data);
 					return;
 				}
 
@@ -109,8 +112,9 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 			if (!addr) {
 				wpa_printf(MSG_ERROR,
-				  "%s:%d Failed to alloc %d bytes\n",
-				  __func__, __LINE__, ETH_ALEN);
+				  "%s:%d EVENT_ASSOC %u Failed to alloc addr %d bytes\n",
+				  __func__, __LINE__, event, ETH_ALEN);
+				os_free(msg.data);
 				return;
 			}
 
@@ -122,8 +126,10 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!req_ies) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d Failed to alloc %d bytes\n",
-					  __func__, __LINE__, data->assoc_info.req_ies_len);
+					  "%s:%d EVENT_ASSOC %u Failed to alloc req_ies %d bytes\n",
+					  __func__, __LINE__, event, data->assoc_info.req_ies_len);
+					os_free(msg.data);
+					os_free(addr);
 					return;
 				}
 
@@ -136,8 +142,12 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!resp_ies) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d Failed to alloc %d bytes\n",
-					  __func__, __LINE__, data->assoc_info.resp_ies_len);
+					  "%s:%d EVENT_ASSOC %u Failed to alloc resp_ies %d bytes\n",
+					  __func__, __LINE__, event, data->assoc_info.resp_ies_len);
+					os_free(msg.data);
+					os_free(addr);
+					if (data_tmp->assoc_info.req_ies)
+						os_free((void *)(data_tmp->assoc_info.req_ies));
 					return;
 				}
 
@@ -150,8 +160,14 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!resp_frame) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d Failed to alloc %d bytes\n",
-					  __func__, __LINE__, data->assoc_info.resp_frame_len);
+					  "%s:%d EVENT_ASSOC %u Failed to alloc resp_frame %d bytes\n",
+					  __func__, __LINE__, event, data->assoc_info.resp_frame_len);
+					os_free(msg.data);
+					os_free(addr);
+					if (data_tmp->assoc_info.req_ies)
+						os_free((void *)(data_tmp->assoc_info.req_ies));
+					if (data_tmp->assoc_info.resp_ies)
+						os_free((void *)(data_tmp->assoc_info.resp_ies));
 					return;
 				}
 
@@ -165,8 +181,9 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 			if (!bssid) {
 				wpa_printf(MSG_ERROR,
-				  "%s:%d Failed to alloc %d bytes\n",
-				  __func__, __LINE__, ETH_ALEN);
+				  "%s:%d EVENT_ASSOC_REJECT %u Failed to alloc bssid %d bytes\n",
+				  __func__, __LINE__,  event, ETH_ALEN);
+				os_free(msg.data);
 				return;
 			}
 
@@ -178,8 +195,10 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!resp_ies) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d Failed to alloc %d bytes\n",
-					  __func__, __LINE__, data->assoc_reject.resp_ies_len);
+					  "%s:%d EVENT_ASSOC_REJECT %u Failed to alloc resp_ies %d bytes\n",
+					  __func__, __LINE__,  event, data->assoc_reject.resp_ies_len);
+					os_free(msg.data);
+					os_free(bssid);
 					return;
 				}
 
@@ -193,8 +212,9 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 			if (!sa) {
 				wpa_printf(MSG_ERROR,
-				  "%s:%d Failed to alloc %d bytes\n",
-				  __func__, __LINE__, ETH_ALEN);
+				  "%s:%d EVENT_DEAUTH %u Failed to alloc sa %d bytes\n",
+				  __func__, __LINE__,  event, ETH_ALEN);
+				os_free(msg.data);
 				return;
 			}
 
@@ -205,8 +225,10 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!ie) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d Failed to alloc %d bytes\n",
-					  __func__, __LINE__, data->deauth_info.ie_len);
+					  "%s:%d EVENT_DEAUTH %u Failed to alloc ie %d bytes\n",
+					  __func__, __LINE__,  event, data->deauth_info.ie_len);
+					os_free(msg.data);
+					os_free(sa);
 					return;
 				}
 
@@ -219,8 +241,9 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 			if (!sa) {
 				wpa_printf(MSG_ERROR,
-				  "%s:%d Failed to alloc %d bytes\n",
-				  __func__, __LINE__, ETH_ALEN);
+				  "%s:%d EVENT_DISASSOC %u Failed to alloc sa %d bytes\n",
+				  __func__, __LINE__,  event, ETH_ALEN);
+				os_free(msg.data);
 				return;
 			}
 
@@ -231,8 +254,10 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!ie) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d Failed to alloc %d bytes\n",
-					  __func__, __LINE__, data->disassoc_info.ie_len);
+					  "%s:%d EVENT_DISASSOC %u Failed to alloc ie %d bytes\n",
+					  __func__, __LINE__,  event, data->disassoc_info.ie_len);
+					os_free(msg.data);
+					os_free(sa);
 					return;
 				}
 
@@ -246,15 +271,21 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 			if (!sa) {
 				wpa_printf(MSG_ERROR,
-				  "%s:%d Failed to alloc %d bytes\n",
-				  __func__, __LINE__, ETH_ALEN);
+				  "%s:%d EVENT_UNPROT_DEAUTH %u Failed to alloc sa %d bytes\n",
+				  __func__, __LINE__,  event, ETH_ALEN);
+				os_free(msg.data);
+				if (da)
+					os_free(da);
 				return;
 			}
 
 			if (!da) {
 				wpa_printf(MSG_ERROR,
-				  "%s:%d Failed to alloc %d bytes\n",
-				  __func__, __LINE__, ETH_ALEN);
+				  "%s:%d EVENT_UNPROT_DEAUTH %u Failed to alloc da %d bytes\n",
+				  __func__, __LINE__,  event, ETH_ALEN);
+				os_free(msg.data);
+				if (sa)
+					os_free(sa);
 				return;
 			}
 			os_memcpy(sa, data->unprot_deauth.sa, ETH_ALEN);
@@ -268,15 +299,21 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 			if (!sa) {
 				wpa_printf(MSG_ERROR,
-				  "%s:%d Failed to alloc %d bytes\n",
-				  __func__, __LINE__, ETH_ALEN);
+				  "%s:%d EVENT_UNPROT_DISASSOC %u Failed to alloc sa %d bytes\n",
+				  __func__, __LINE__,  event, ETH_ALEN);
+				os_free(msg.data);
+				if (da)
+					os_free(da);
 				return;
 			}
 
 			if (!da) {
 				wpa_printf(MSG_ERROR,
-				  "%s:%d Failed to alloc %d bytes\n",
-				  __func__, __LINE__, ETH_ALEN);
+				  "%s:%d EVENT_UNPROT_DISASSOC %u Failed to alloc da %d bytes\n",
+				  __func__, __LINE__,  event, ETH_ALEN);
+				os_free(msg.data);
+				if (sa)
+					os_free(sa);
 				return;
 			}
 			os_memcpy(sa, data->unprot_disassoc.sa, ETH_ALEN);


### PR DESCRIPTION
Fix memory leak in wpa_supplicant_event_wrapper().