### PR TITLE
[noup] utils: os_zephyr: Fall back to sys_rand if no csrand

### DIFF
--- a/src/utils/os_zephyr.c
+++ b/src/utils/os_zephyr.c
@@ -145,9 +145,13 @@ void os_daemonize_terminate(const char *pid_file)
 
 int os_get_random(unsigned char *buf, size_t len)
 {
-	sys_csrand_get(buf, len);
+#if defined(CONFIG_ENTROPY_HAS_DRIVER)
+	return sys_csrand_get(buf, len);
+#else
+	sys_rand_get(buf, len);
 
 	return 0;
+#endif
 }
 
 unsigned long os_random(void)


### PR DESCRIPTION
When compiling zephyr with the test random generator, sys_csrand_get() is not available. Allow fallback to sys_rand_get() if no entropy driver exists.

Without this patch, it is not possible to build the nrf70 WiFi device driver as it depends on WPA_SUPPLICANT, which depends on `sys_csrand_get()` for boards without hardware RNG.

```
/home/nordic/Documents/zephyr-sdk/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: modules/hostap/libmodules__hostap.a(os_zephyr.c.obj): in function `sys_csrand_get':
/home/nordic/Documents/zephyr-1/build/zephyr/include/generated/zephyr/syscalls/random.h:61: undefined reference to `z_impl_sys_csrand_get'
collect2: error: ld returned 1 exit status
```