### PR TITLE
[toup] zephyr: crypto: Fix for embedtls

### DIFF
--- a/src/crypto/tls.h
+++ b/src/crypto/tls.h
@@ -112,6 +112,8 @@ struct tls_config {
 #define TLS_CONN_ENABLE_TLSv1_1 BIT(15)
 #define TLS_CONN_ENABLE_TLSv1_2 BIT(16)
 #define TLS_CONN_TEAP_ANON_DH BIT(17)
+#define TLS_CONN_CNSA BIT(18)
+#define TLS_CONN_CNSA_NO_ECDH BIT(19)
 
 /**
  * struct tls_connection_params - Parameters for TLS connection

--- a/src/crypto/tls_mbedtls_alt.c
+++ b/src/crypto/tls_mbedtls_alt.c
@@ -1734,6 +1734,7 @@ static int tls_mbedtls_set_params(struct tls_conf *tls_conf, const struct tls_co
     int ret = mbedtls_ssl_config_defaults(
         &tls_conf->conf, tls_ctx_global.tls_conf ? MBEDTLS_SSL_IS_SERVER : MBEDTLS_SSL_IS_CLIENT,
         MBEDTLS_SSL_TRANSPORT_STREAM,
+        (tls_conf->flags & TLS_CONN_CNSA) ? MBEDTLS_SSL_PRESET_CNSA :
         (tls_conf->flags & TLS_CONN_SUITEB) ? MBEDTLS_SSL_PRESET_SUITEB : MBEDTLS_SSL_PRESET_DEFAULT);
     if (ret != 0)
     {
@@ -1751,7 +1752,7 @@ static int tls_mbedtls_set_params(struct tls_conf *tls_conf, const struct tls_co
         mbedtls_ssl_conf_cert_profile(&tls_conf->conf, &tls_mbedtls_crt_profile_suiteb192);
         mbedtls_ssl_conf_dhm_min_bitlen(&tls_conf->conf, 3072);
     }
-    else if (tls_conf->flags & TLS_CONN_SUITEB)
+    else if ((tls_conf->flags & TLS_CONN_SUITEB) | (tls_conf->flags & TLS_CONN_CNSA))
     {
         /* treat as suiteb192 while allowing any PK algorithm */
         mbedtls_ssl_conf_cert_profile(&tls_conf->conf, &tls_mbedtls_crt_profile_suiteb192_anypk);
@@ -1780,10 +1781,10 @@ static int tls_mbedtls_set_params(struct tls_conf *tls_conf, const struct tls_co
         if (!tls_mbedtls_set_ciphers(tls_conf, params->openssl_ciphers))
             return -1;
     }
-    else if (tls_conf->flags & TLS_CONN_SUITEB)
+    else if (tls_conf->flags & TLS_CONN_CNSA)
     {
         /* special-case a select set of ciphers for hwsim tests */
-        if (!tls_mbedtls_set_ciphers(tls_conf, (tls_conf->flags & TLS_CONN_SUITEB_NO_ECDH) ?
+        if (!tls_mbedtls_set_ciphers(tls_conf, (tls_conf->flags & TLS_CONN_CNSA_NO_ECDH) ?
                                                    "DHE-RSA-AES256-GCM-SHA384" :
                                                    "ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384"))
             return -1;

--- a/src/eap_peer/eap_tls_common.c
+++ b/src/eap_peer/eap_tls_common.c
@@ -102,6 +102,14 @@ static void eap_tls_params_flags(struct tls_connection_params *params,
 		params->flags |= TLS_CONN_SUITEB_NO_ECDH;
 	if (os_strstr(txt, "tls_suiteb_no_ecdh=0"))
 		params->flags &= ~TLS_CONN_SUITEB_NO_ECDH;
+	if (os_strstr(txt, "tls_cnsa=1"))
+		params->flags |= TLS_CONN_CNSA;
+	if (os_strstr(txt, "tls_cnsa=0"))
+		params->flags &= ~TLS_CONN_CNSA;
+	if (os_strstr(txt, "tls_cnsa_no_ecdh=1"))
+		params->flags |= TLS_CONN_CNSA_NO_ECDH;
+	if (os_strstr(txt, "tls_cnsa_no_ecdh=0"))
+		params->flags &= ~TLS_CONN_CNSA_NO_ECDH;
 }
 
 


### PR DESCRIPTION
Fix mbedtls for WPA3 enterprise suiteb192 rsa3k connect fail.

Let default config not use MBEDTLS_SSL_PRESET_SUITEB as input mbedtls_ssl_config_defaults().
For rsa3k case has TLS_CONN_SUITEB flag and will
choose MBEDTLS_SSL_PRESET_SUITEB as input.
Then the signature algorithm will set to
ssl_tls12_preset_suiteb_sig_algs which removed rsa. Then will cause EAP Hello packet not include rsa
in sig_alg and AP will return EAP failure.
Use MBEDTLS_SSL_PRESET_DEFAULT as input.