### PR TITLE
[noup]: hostap: fix start ap fail

### DIFF
--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -1378,7 +1378,7 @@ static int _wpa_drv_zep_set_key(void *priv,
 		goto out;
 	}
 
-	if (!net_if_is_up(iface)) {
+	if (!net_if_is_admin_up(iface)) {
 		goto out;
 	}
 

--- a/wpa_supplicant/ctrl_iface_zephyr.c
+++ b/wpa_supplicant/ctrl_iface_zephyr.c
@@ -69,7 +69,7 @@ static void wpa_supplicant_ctrl_iface_send(struct wpa_supplicant *wpa_s,
 
 	idx = 0;
 	if (len > MAX_CTRL_MSG_LEN) {
-		wpa_printf(MSG_ERROR, "CTRL_MSG too long");
+		wpa_printf(MSG_DEBUG, "CTRL_MSG too long");
 		return;
 	}
 

--- a/wpa_supplicant/wpa_cli_zephyr.c
+++ b/wpa_supplicant/wpa_cli_zephyr.c
@@ -143,7 +143,7 @@ static void wpa_cli_recv_pending(struct wpa_ctrl *ctrl, struct wpa_supplicant *w
 
 			msg->msg[msg->msg_len] = '\0';
 			if (msg->msg_len >= MAX_CTRL_MSG_LEN) {
-				wpa_printf(MSG_INFO, "Too long message received.\n");
+				wpa_printf(MSG_DEBUG, "Too long message received.\n");
 				continue;
 			}
 


### PR DESCRIPTION
1. when enable hostapd, print Interface initialization failed log.
wpa_init_keys will check the netif running status when setup bss but fail.
use net_if_is_admin_up to check interface up status.
2. change "CTRL_MSG too long" to debug log level to avoid misunderstanding in normal case.