### PR TITLE
[noup] SAE: reduce loop iterations of PWE derivation

### DIFF
--- a/src/common/sae.c
+++ b/src/common/sae.c
@@ -384,6 +384,13 @@ static int sae_derive_pwe_ecc(struct sae_data *sae, const u8 *addr1,
 		found |= res * 0xff;
 		wpa_printf(MSG_DEBUG, "SAE: pwd-seed result %d found=0x%02x",
 			   res, found);
+#ifdef CONFIG_SAE_PWE_EARLY_EXIT
+		if (found)
+			/* For low-performance processors, reduce loop iterations of PWE
+			 * derivation to reduce the time to generate PWE.
+			 */
+			break;
+#endif /* CONFIG_SAE_PWE_EARLY_EXIT */
 	}
 
 	if (!found) {


### PR DESCRIPTION
For low-performance processors, reduce the number of loop iterations for PWE derivation to reduce the time to generate PWE. Add CONFIG_SAE_PWE_EARLY_EXIT macro to enable it.