### PR TITLE
[nrf noup] crypto: Fix usage of AES mode

### DIFF
--- a/src/crypto/crypto_mbedtls.c
+++ b/src/crypto/crypto_mbedtls.c
@@ -806,13 +806,13 @@ int omac1_aes_vector(
 
 	switch (key_len) {
 	case 16:
-		cipher_type = MBEDTLS_CIPHER_AES_128_ECB;
+		cipher_type = MBEDTLS_CIPHER_AES_128_CBC;
 		break;
 	case 24:
-		cipher_type = MBEDTLS_CIPHER_AES_192_ECB;
+		cipher_type = MBEDTLS_CIPHER_AES_192_CBC;
 		break;
 	case 32:
-		cipher_type = MBEDTLS_CIPHER_AES_256_ECB;
+		cipher_type = MBEDTLS_CIPHER_AES_256_CBC;
 		break;
 	default:
 		cipher_type = MBEDTLS_CIPHER_NONE;

--- a/src/crypto/crypto_mbedtls_alt.c
+++ b/src/crypto/crypto_mbedtls_alt.c
@@ -860,13 +860,13 @@ int omac1_aes_vector(const u8 *key, size_t key_len, size_t num_elem, const u8 *a
     switch (key_len)
     {
         case 16:
-            cipher_type = MBEDTLS_CIPHER_AES_128_ECB;
+            cipher_type = MBEDTLS_CIPHER_AES_128_CBC;
             break;
         case 24:
-            cipher_type = MBEDTLS_CIPHER_AES_192_ECB;
+            cipher_type = MBEDTLS_CIPHER_AES_192_CBC;
             break;
         case 32:
-            cipher_type = MBEDTLS_CIPHER_AES_256_ECB;
+            cipher_type = MBEDTLS_CIPHER_AES_256_CBC;
             break;
         default:
             return -1;


### PR DESCRIPTION
802.11 uses CMAC (CBC MAC) for authentication (previously called OMAC1) the MbedTLS wrapper wrongly uses ECB which in unsecure and also wrong.

Fix it by using CBC.