### PR TITLE
[toup] zephyr: fix the build error that unknown FILE

### DIFF
--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -11,6 +11,9 @@
 
 #if defined(__ZEPHYR__)
 typedef long long os_time_t;
+#ifndef FILE
+typedef __FILE FILE;
+#endif
 #else
 typedef long os_time_t;
 #endif


### PR DESCRIPTION
When build the Matter over Wi-Fi with NEWLIB enabled, there is build error shows 'error: unknown type name 'FILE' ', adding this change can fix this build error, and don't affect the case that NEWLIB disabled.