### PR TITLE
[noup] zephyr: Add CAC support if AP started on DFS channel

### DIFF
--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -972,6 +972,26 @@ static void wpa_drv_zep_event_ecsa_complete(struct zep_drv_if_ctx *if_ctx, union
 	wpa_supplicant_event_wrapper(if_ctx->supp_if_ctx, EVENT_CH_SWITCH, event);
 }
 
+static void wpa_drv_zep_event_dfs_cac_started(struct zep_drv_if_ctx *if_ctx, union wpa_event_data *event)
+{
+#ifdef CONFIG_WIFI_NM_HOSTAPD_AP
+	if (if_ctx->hapd)
+		hostapd_event_wrapper(if_ctx->hapd, EVENT_DFS_CAC_STARTED, event);
+	else
+#endif
+		wpa_supplicant_event_wrapper(if_ctx->supp_if_ctx, EVENT_DFS_CAC_STARTED, event);
+}
+
+static void wpa_drv_zep_event_dfs_cac_finished(struct zep_drv_if_ctx *if_ctx, union wpa_event_data *event)
+{
+#ifdef CONFIG_WIFI_NM_HOSTAPD_AP
+	if (if_ctx->hapd)
+		hostapd_event_wrapper(if_ctx->hapd, EVENT_DFS_CAC_FINISHED, event);
+	else
+#endif
+		wpa_supplicant_event_wrapper(if_ctx->supp_if_ctx, EVENT_DFS_CAC_FINISHED, event);
+}
+
 static struct hostapd_hw_modes *
 wpa_driver_wpa_supp_postprocess_modes(struct hostapd_hw_modes *modes,
 		u16 *num_modes)
@@ -1311,6 +1331,8 @@ static void *wpa_drv_zep_hapd_init(struct hostapd_data *hapd, struct wpa_init_pa
 	callbk_fns.mac_changed       = wpa_drv_zep_event_mac_changed;
 	callbk_fns.chan_list_changed = wpa_drv_zep_event_chan_list_changed;
 	callbk_fns.ecsa_complete     = wpa_drv_zep_event_ecsa_complete;
+	callbk_fns.dfs_cac_started   = wpa_drv_zep_event_dfs_cac_started;
+	callbk_fns.dfs_cac_finished  = wpa_drv_zep_event_dfs_cac_finished;
 
 	if_ctx->dev_priv = dev_ops->hapd_init(if_ctx, params->ifname, &callbk_fns);
 	if (!if_ctx->dev_priv) {

--- a/src/drivers/driver_zephyr.h
+++ b/src/drivers/driver_zephyr.h
@@ -201,6 +201,12 @@ struct zep_wpa_supp_dev_callbk_fns {
 
 	void (*ecsa_complete)(struct zep_drv_if_ctx *if_ctx,
 			      union wpa_event_data *event);
+
+	void (*dfs_cac_started)(struct zep_drv_if_ctx *if_ctx,
+				union wpa_event_data *event);
+
+	void (*dfs_cac_finished)(struct zep_drv_if_ctx *if_ctx,
+				 union wpa_event_data *event);
 };
 
 struct zep_hostapd_dev_callbk_fns


### PR DESCRIPTION
If AP starts on DFS channel, hostapd will wait for CAC start and finish event. Added CAC callback functions in Zephyr driver.