### PR TITLE
DPP bug fixes

### DIFF
--- a/hostapd/hostapd_cli_cmds.c
+++ b/hostapd/hostapd_cli_cmds.c
@@ -58,24 +58,21 @@ out:
 
 }
 
-
 static int hostapd_cli_cmd_set(struct wpa_ctrl *ctrl, int argc, char *argv[])
 {
-        char cmd[2048];
-        int res;
+	char cmd[256];
+	int res;
 
-        if (argc != 2) {
-                printf("Invalid SET command: needs two arguments (variable "
-                       "name and value)\n");
-                return -1;
-        }
+	if (argc == 1) {
+		res = os_snprintf(cmd, sizeof(cmd), "SET %s ", argv[0]);
+		if (os_snprintf_error(sizeof(cmd), res)) {
+			wpa_printf(MSG_INFO, "Too long SET command.\n");
+			return -1;
+		}
+		return hostapd_cli_cmd(ctrl, cmd, 0, argc, argv);
+	}
 
-        res = os_snprintf(cmd, sizeof(cmd), "SET %s %s", argv[0], argv[1]);
-        if (os_snprintf_error(sizeof(cmd), res)) {
-                printf("Too long SET command.\n");
-                return -1;
-        }
-        return hostapd_ctrl_command(ctrl, cmd);
+	return hostapd_cli_cmd(ctrl, "SET", 2, argc, argv);
 }
 
 

--- a/hostapd/hostapd_cli_zephyr.c
+++ b/hostapd/hostapd_cli_zephyr.c
@@ -263,7 +263,7 @@ static void hostapd_cli_recv_pending(struct wpa_ctrl *ctrl, struct hostapd_data 
 
 			msg->msg[msg->msg_len] = '\0';
 			wpa_printf(MSG_DEBUG, "Received len: %d, msg_len:%d - %s->END\n",
-				   len, msg->msg_len, msg->msg);
+				   plen, msg->msg_len, msg->msg);
 			if (msg->msg_len >= MAX_CTRL_MSG_LEN) {
 				wpa_printf(MSG_INFO, "Too long message received.\n");
 				continue;

--- a/hostapd/hostapd_cli_zephyr.c
+++ b/hostapd/hostapd_cli_zephyr.c
@@ -10,7 +10,6 @@
 #include "includes.h"
 
 #include "common/cli.h"
-#include "common/wpa_ctrl.h"
 #include "utils/common.h"
 #include "utils/eloop.h"
 #include "utils/edit.h"
@@ -211,6 +210,11 @@ static int _wpa_ctrl_command(struct wpa_ctrl *ctrl, const char *cmd, int print, 
 int hostapd_ctrl_command(struct wpa_ctrl *ctrl, const char *cmd)
 {
 	return _wpa_ctrl_command(ctrl, cmd, 0, NULL);
+}
+
+int hostapd_ctrl_command_interactive(struct wpa_ctrl *ctrl, const char *cmd)
+{
+	return _wpa_ctrl_command(ctrl, cmd, 1, NULL);
 }
 
 int zephyr_hostapd_cli_cmd_resp(const char *cmd, char *resp)

--- a/hostapd/hostapd_cli_zephyr.h
+++ b/hostapd/hostapd_cli_zephyr.h
@@ -11,10 +11,14 @@
 
 #include <zephyr/kernel.h>
 
+#include "common/wpa_ctrl.h"
+
 void hostapd_cli_msg_cb(char *msg, size_t len);
 int hostapd_request(struct wpa_ctrl *ctrl, int argc, char *argv[]);
 int hostapd_ctrl_command(struct wpa_ctrl *ctrl, const char *cmd);
+int hostapd_ctrl_command_interactive(struct wpa_ctrl *ctrl, const char *cmd);
 int zephyr_hostapd_cli_cmd_resp(const char *cmd, char *resp);
 int zephyr_hostapd_cli_cmd_v(const char *fmt, ...);
 int zephyr_hostapd_ctrl_init(void *ctx);
+int zephyr_hostapd_ctrl_zephyr_cmd(int argc, const char *argv[]);
 #endif /* __HOSTAPD_CLI_ZEPHYR_H_ */

--- a/src/ap/hostapd.h
+++ b/src/ap/hostapd.h
@@ -154,6 +154,13 @@ struct hostapd_sae_commit_queue {
  * struct hostapd_data - hostapd per-BSS data structure
  */
 struct hostapd_data {
+#if defined(__ZEPHYR__) && defined(HOSTAPD)
+	/** Zephyr has coexistence of hostapd and wpa_supplicant.
+	 * To verify if ctx is hostapd or wpa_supplicant in wpa_msg,
+	 * this should be the first parameter
+	 */
+	int is_hostapd;
+#endif
 	struct hostapd_iface *iface;
 	struct hostapd_config *iconf;
 	struct hostapd_bss_config *conf;

--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -2594,6 +2594,29 @@ out:
 	return ret;
 }
 
+void wpa_drv_zep_send_action_cancel_wait(void *priv)
+{
+	struct zep_drv_if_ctx *if_ctx = NULL;
+	const struct zep_wpa_supp_dev_ops *dev_ops = NULL;
+
+	if (!priv) {
+		wpa_printf(MSG_ERROR, "%s: Invalid handle", __func__);
+		goto out;
+	}
+
+	if_ctx = priv;
+	dev_ops = get_dev_ops(if_ctx->dev_ctx);
+
+	if (!dev_ops || !dev_ops->send_action_cancel_wait) {
+		wpa_printf(MSG_DEBUG, "%s: send_action_cancel_wait op not supported", __func__);
+		goto out;
+	}
+
+	dev_ops->send_action_cancel_wait(if_ctx->dev_priv);
+
+out:
+	return;
+}
 
 const struct wpa_driver_ops wpa_driver_zep_ops = {
 	.name = "zephyr",
@@ -2643,4 +2666,5 @@ const struct wpa_driver_ops wpa_driver_zep_ops = {
 	.dpp_listen = wpa_drv_zep_dpp_listen,
 	.remain_on_channel = wpa_drv_zep_remain_on_channel,
 	.cancel_remain_on_channel = wpa_drv_zep_cancel_remain_on_channel,
+	.send_action_cancel_wait = wpa_drv_zep_send_action_cancel_wait,
 };

--- a/src/drivers/driver_zephyr.h
+++ b/src/drivers/driver_zephyr.h
@@ -338,6 +338,7 @@ struct zep_wpa_supp_dev_ops {
 	int (*remain_on_channel)(void *priv, unsigned int freq, unsigned int duration);
 	int (*cancel_remain_on_channel)(void *priv);
 	int (*get_inact_sec)(void *if_priv, const u8 *addr);
+	void (*send_action_cancel_wait)(void *priv);
 };
 
 #endif /* DRIVER_ZEPHYR_H */

--- a/wpa_supplicant/ctrl_iface_zephyr.c
+++ b/wpa_supplicant/ctrl_iface_zephyr.c
@@ -372,3 +372,12 @@ wpa_supplicant_global_ctrl_iface_deinit(struct ctrl_iface_global_priv *priv)
 
 	os_free(priv);
 }
+
+#ifdef CONFIG_WIFI_NM_HOSTAPD_AP
+void wpa_supplicant_msg_send(void *ctx, int level,
+			     enum wpa_msg_type type,
+			     const char *txt, size_t len)
+{
+	wpa_supplicant_ctrl_iface_msg_cb(ctx, level, type, txt, len);
+}
+#endif

--- a/wpa_supplicant/wpa_cli_zephyr.c
+++ b/wpa_supplicant/wpa_cli_zephyr.c
@@ -142,6 +142,8 @@ static void wpa_cli_recv_pending(struct wpa_ctrl *ctrl, struct wpa_supplicant *w
 			struct conn_msg *msg = (struct conn_msg *)buf;
 
 			msg->msg[msg->msg_len] = '\0';
+			wpa_printf(MSG_DEBUG, "Received len: %d, msg_len:%d - %s->END\n",
+				   plen, msg->msg_len, msg->msg);
 			if (msg->msg_len >= MAX_CTRL_MSG_LEN) {
 				wpa_printf(MSG_DEBUG, "Too long message received.\n");
 				continue;

--- a/wpa_supplicant/wpa_supplicant_i.h
+++ b/wpa_supplicant/wpa_supplicant_i.h
@@ -689,6 +689,13 @@ struct active_scs_elem {
  * core functions.
  */
 struct wpa_supplicant {
+#if defined(__ZEPHYR__) && defined(HOSTAPD)
+	/** Zephyr has coexistence of hostapd and wpa_supplicant.
+	 * To verify if ctx is hostapd or wpa_supplicant in wpa_msg,
+	 * this should be the first parameter
+	 */
+	int is_hostapd;
+#endif
 	struct wpa_global *global;
 	struct wpa_radio *radio; /* shared radio context */
 	struct dl_list radio_list; /* list head: struct wpa_radio::ifaces */


### PR DESCRIPTION
510c2609a8b62acdcd1deaa4e2a9c20bb303f234
[noup] zephyr: fix hostapd_cli set command parse wrong in zephyr
    
    hostapd_config_parse_key_mgmt can parse more than two argcs.
    And hostapd_cli shell command has one more "interactive" argv,
    which makes argc not equal to 2.
    So align with wpa_cli_cmd_set.

a41113eb54fc208b0e22368b9891e13cdba83540
[noup] add hostapd_cli shell support
    
    Add hostapd_cli shell command.
    Porting from zephyr wpa_cli impl.

83d7a2b827515e9c3142fdc629679fb317286be4
[noup] fix hostapd ctrl msg receive build error
    
    Fix build error that 'len' is undefined in hostapd_cli_recv_pending.

960516c8e32a662b73b9aac012d82cc814aa71c4
[noup] hostapd: add dispatch for hostapd and wpa_supplicant wpa_msg
    
    When we have coexistence of hostapd and wpa_supplicant,
    wpa_msg has different implementation and differenet context,
    struct wpa_supplicant and struct hostapd_data.
    So to let them work together, we need to have common implementation
    for wpa_msg and dispatch msgs for hostapd and wpa_supplicant.
    
    In this case add common member is_hostapd in struct wpa_supplicant
    and struct hostapd_data, to judge if wpa_msg context is wpa_supplicant
    or hostapd. In hostapd it is 1.
    And wrap wpa_supplicant msg_cb and hostapd msg_cb by apis called by
    common msg_cb.
    
    So add common member is_hostapd in struct wpa_supplicant
    and struct hostapd_data, to judge if wpa_msg context is wpa_supplicant
    or hostapd. In hostapd it is 1.
    And wrap wpa_supplicant msg_cb and hostapd msg_cb by apis called by
    common msg_cb.

a00f0b566f641f5dffd0da1d16020f8f56bbb29c
[noup] zephyr: fix DPP-Auth initiation failed no response received
    
    Configurator send DPP auth request on channel 1 and need to
    receive DPP auth response on channel 6.
    This requires support of send_action_cancel_wait ops to cancel
    remain on channel after TX success on channel 1, and then
    remain on channel 6.
    But previous code does not support send_action_cancel_wait ops.
    
    So add send_action_cancel_wait ops support to fix this case.