### PR TITLE
[noup] zephyr: revert zephyr change for os_time_t to origin

### DIFF
--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -10,13 +10,11 @@
 #define OS_H
 
 #if defined(__ZEPHYR__)
-typedef long long os_time_t;
 #ifndef FILE
 typedef __FILE FILE;
 #endif
-#else
-typedef long os_time_t;
 #endif
+typedef long os_time_t;
 
 /**
  * os_sleep - Sleep (sec, usec)

--- a/src/utils/os_zephyr.c
+++ b/src/utils/os_zephyr.c
@@ -29,8 +29,8 @@ int os_get_time(struct os_time *t)
 	struct timeval tv;
 
 	res = gettimeofday(&tv, NULL);
-	t->sec = tv.tv_sec;
-	t->usec = tv.tv_usec;
+	t->sec = (os_time_t)tv.tv_sec;
+	t->usec = (os_time_t)tv.tv_usec;
 	return res;
 }
 

--- a/wpa_supplicant/ctrl_iface.c
+++ b/wpa_supplicant/ctrl_iface.c
@@ -8618,7 +8618,7 @@ static int wpas_ctrl_radio_work_show(struct wpa_supplicant *wpa_s,
 		int ret;
 
 		os_reltime_sub(&now, &work->time, &diff);
-		ret = os_snprintf(pos, end - pos, "%s@%s:%u:%u:%lld.%06lld\n",
+		ret = os_snprintf(pos, end - pos, "%s@%s:%u:%u:%ld.%06ld\n",
 				  work->type, work->wpa_s->ifname, work->freq,
 				  work->started, diff.sec, diff.usec);
 		if (os_snprintf_error(end - pos, ret))

--- a/wpa_supplicant/events.c
+++ b/wpa_supplicant/events.c
@@ -5043,7 +5043,7 @@ void wpa_supplicant_event(void *ctx, enum wpa_event_type event,
 			os_get_reltime(&wpa_s->scan_start_time);
 			os_reltime_sub(&wpa_s->scan_start_time,
 				       &wpa_s->scan_trigger_time, &diff);
-			wpa_dbg(wpa_s, MSG_DEBUG, "Own scan request started a scan in %lld.%06lld seconds",
+			wpa_dbg(wpa_s, MSG_DEBUG, "Own scan request started a scan in %ld.%06ld seconds",
 				diff.sec, diff.usec);
 			wpa_s->own_scan_requested = 0;
 			wpa_s->own_scan_running = 1;
@@ -5078,7 +5078,7 @@ void wpa_supplicant_event(void *ctx, enum wpa_event_type event,
 			os_reltime_sub(&now, &wpa_s->scan_start_time, &diff);
 			wpa_s->scan_start_time.sec = 0;
 			wpa_s->scan_start_time.usec = 0;
-			wpa_dbg(wpa_s, MSG_DEBUG, "Scan completed in %lld.%06lld seconds",
+			wpa_dbg(wpa_s, MSG_DEBUG, "Scan completed in %ld.%06ld seconds",
 				diff.sec, diff.usec);
 		}
 		if (wpa_supplicant_event_scan_results(wpa_s, data))

--- a/wpa_supplicant/wnm_sta.c
+++ b/wpa_supplicant/wnm_sta.c
@@ -766,7 +766,7 @@ compare_scan_neighbor_results(struct wpa_supplicant *wpa_s, os_time_t age_secs,
 			    os_reltime_expired(&now, &target->last_update,
 					       age_secs)) {
 				wpa_printf(MSG_DEBUG,
-					   "Candidate BSS is more than %lld seconds old",
+					   "Candidate BSS is more than %ld seconds old",
 					   age_secs);
 				continue;
 			}

--- a/wpa_supplicant/wpa_supplicant.c
+++ b/wpa_supplicant/wpa_supplicant.c
@@ -6251,7 +6251,7 @@ static void radio_start_next_work(void *eloop_ctx, void *timeout_ctx)
 	os_get_reltime(&now);
 	os_reltime_sub(&now, &work->time, &diff);
 	wpa_dbg(wpa_s, MSG_DEBUG,
-		"Starting radio work '%s'@%p after %lld.%06lld second wait",
+		"Starting radio work '%s'@%p after %ld.%06ld second wait",
 		work->type, work, diff.sec, diff.usec);
 	work->started = 1;
 	work->time = now;
@@ -6449,7 +6449,7 @@ void radio_work_done(struct wpa_radio_work *work)
 
 	os_get_reltime(&now);
 	os_reltime_sub(&now, &work->time, &diff);
-	wpa_dbg(wpa_s, MSG_DEBUG, "Radio work '%s'@%p %s in %lld.%06lld seconds",
+	wpa_dbg(wpa_s, MSG_DEBUG, "Radio work '%s'@%p %s in %ld.%06ld seconds",
 		work->type, work, started ? "done" : "canceled",
 		diff.sec, diff.usec);
 	radio_work_free(work);


### PR DESCRIPTION
Hostap define os_time_t as long but zephyr add own definition to long long and change hostap original code to fix warnings. Thus when DPP enabled, unfixed warning will pop out. We do not want to change so many original hostap code. So it is better to remain original os_time_t definition as long. Fix it by revert os_time_t own definition for zephyr and related printf format change also.

And fix coverity issue by converting time to os_time_t in os_get_time.