### PR TITLE
[noup] zephyr: Fix build error when hostapd enabled

### DIFF
--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -400,7 +400,7 @@ void wpa_drv_zep_event_mac_changed(struct zep_drv_if_ctx *if_ctx)
 	const struct net_linkaddr *link_addr = NULL;
 
 	if (if_ctx->hapd) {
-		link_addr = net_if_get_link_addr(net_if_get_wifi_uap());
+		link_addr = net_if_get_link_addr(net_if_get_wifi_sap());
 		os_memcpy(if_ctx->hapd->own_addr, link_addr->addr, link_addr->len);
 	}
 	else


### PR DESCRIPTION
Fix build error when CONFIG_WIFI_NM_HOSTAPD_AP is enabled, should use the new API net_if_get_wifi_sap().