### PR TITLE
[toup] zephyr: crypto: Add SHA1 PBKDF2 using PSA APIs

### DIFF
--- a/port/mbedtls/supp_psa_api.h
+++ b/port/mbedtls/supp_psa_api.h
@@ -52,6 +52,12 @@ int hmac_vector_psa(const u8 *key,
                     u8 *mac,
                     mbedtls_md_type_t md_type);
 
+int pbkdf2_sha1_psa(mbedtls_md_type_t md_alg,
+                    const u8 *password, size_t plen,
+                    const unsigned char *salt, size_t slen,
+                    unsigned int iteration_count, uint32_t key_length,
+                    unsigned char *output);
+
 int supp_psa_crypto_init(void);
 void supp_psa_crypto_deinit(void);
 #endif /* SUPP_PSA_API_H */

--- a/src/crypto/crypto_mbedtls_alt.c
+++ b/src/crypto/crypto_mbedtls_alt.c
@@ -722,6 +722,11 @@ int des_encrypt(const u8 *clear, const u8 *key, u8 *cypher)
 #include <mbedtls/pkcs5.h>
 int pbkdf2_sha1(const char *passphrase, const u8 *ssid, size_t ssid_len, int iterations, u8 *buf, size_t buflen)
 {
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_MBEDTLS_PSA
+    return pbkdf2_sha1_psa(MBEDTLS_MD_SHA1, (const u8 *)passphrase,
+                           os_strlen(passphrase), ssid, ssid_len,
+                           iterations, 32, buf) ? -1: 0;
+#else
 #if MBEDTLS_VERSION_NUMBER >= 0x03020200 /* mbedtls 3.2.2 */
     return mbedtls_pkcs5_pbkdf2_hmac_ext(MBEDTLS_MD_SHA1, (const u8 *)passphrase, os_strlen(passphrase), ssid, ssid_len,
                                          iterations, 32, buf) ?
@@ -742,6 +747,7 @@ int pbkdf2_sha1(const char *passphrase, const u8 *ssid, size_t ssid_len, int ite
     mbedtls_md_free(&ctx);
     return ret;
 #endif
+#endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_MBEDTLS_PSA */
 }
 #endif
 


### PR DESCRIPTION
Add PSA API based pbkdf2 wrapper. This wrapper implements pbkdf2 algorithm using only PSA APIs. The PSA API based wrapper is tested for the test vectors defined in J.4.2 in 802.11-2020 and also verified via connection. 