### PR TITLE
[noup] base64: Rename base64_encode/decode functions

### DIFF
--- a/hostapd/sae_pk_gen.c
+++ b/hostapd/sae_pk_gen.c
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
 	fprintf(stderr, "\nFound a valid hash in %llu iterations: %s\n",
 		i + 1, hash_hex);
 
-	b64 = base64_encode(der, der_len, NULL);
+	b64 = hostap_base64_encode(der, der_len, NULL);
 	if (!b64)
 		goto fail;
 	src = pos = b64;

--- a/hs20/client/est.c
+++ b/hs20/client/est.c
@@ -158,7 +158,7 @@ int est_load_cacerts(struct hs20_osu_client *ctx, const char *url)
 		return -1;
 	}
 
-	pkcs7 = base64_decode(resp, resp_len, &pkcs7_len);
+	pkcs7 = hostap_base64_decode(resp, resp_len, &pkcs7_len);
 	if (pkcs7 && pkcs7_len < resp_len / 2) {
 		wpa_printf(MSG_INFO, "Too short base64 decode (%u bytes; downloaded %u bytes) - assume this was binary",
 			   (unsigned int) pkcs7_len, (unsigned int) resp_len);
@@ -639,7 +639,7 @@ int est_build_csr(struct hs20_osu_client *ctx, const char *url)
 			return -1;
 		}
 
-		attrs = base64_decode(resp, resp_len, &attrs_len);
+		attrs = hostap_base64_decode(resp, resp_len, &attrs_len);
 		os_free(resp);
 
 		if (attrs == NULL) {
@@ -733,7 +733,7 @@ int est_simple_enroll(struct hs20_osu_client *ctx, const char *url,
 	}
 	wpa_printf(MSG_DEBUG, "EST simpleenroll response: %s", resp);
 
-	pkcs7 = base64_decode(resp, resp_len, &pkcs7_len);
+	pkcs7 = hostap_base64_decode(resp, resp_len, &pkcs7_len);
 	if (pkcs7 == NULL) {
 		wpa_printf(MSG_INFO, "EST workaround - Could not decode base64, assume this is DER encoded PKCS7");
 		pkcs7 = os_malloc(resp_len);

--- a/hs20/client/osu_client.c
+++ b/hs20/client/osu_client.c
@@ -364,7 +364,7 @@ static int download_cert(struct hs20_osu_client *ctx, xml_node_t *params,
 		return -1;
 	}
 
-	b64 = base64_encode(cert, len, NULL);
+	b64 = hostap_base64_encode(cert, len, NULL);
 	os_free(cert);
 	if (b64 == NULL)
 		return -1;

--- a/hs20/server/spp_server.c
+++ b/hs20/server/spp_server.c
@@ -633,7 +633,7 @@ static xml_node_t * build_username_password(struct hs20_svc *ctx,
 
 	add_text_node(ctx, node, "Username", user);
 
-	b64 = base64_encode(pw, strlen(pw), NULL);
+	b64 = hostap_base64_encode(pw, strlen(pw), NULL);
 	if (b64 == NULL)
 		return NULL;
 	len = os_strlen(b64);
@@ -1602,7 +1602,7 @@ static xml_node_t * spp_exec_get_certificate(struct hs20_svc *ctx,
 
 	xml_node_create_text(ctx->xml, enroll, ns, "estUserID", user);
 
-	b64 = base64_encode(password, strlen(password), NULL);
+	b64 = hostap_base64_encode(password, strlen(password), NULL);
 	if (b64 == NULL) {
 		xml_node_free(ctx->xml, spp_node);
 		return NULL;

--- a/src/common/dpp.c
+++ b/src/common/dpp.c
@@ -330,7 +330,7 @@ static int dpp_parse_uri_pk(struct dpp_bootstrap_info *bi, const char *info)
 	if (!end)
 		return -1;
 
-	data = base64_decode(info, end - info, &data_len);
+	data = hostap_base64_decode(info, end - info, &data_len);
 	if (!data) {
 		wpa_printf(MSG_DEBUG,
 			   "DPP: Invalid base64 encoding on URI public-key");
@@ -3060,7 +3060,7 @@ static u8 * dpp_get_csr_attrs(const u8 *attrs, size_t attrs_len, size_t *len)
 	b64 = dpp_get_attr(attrs, attrs_len, DPP_ATTR_CSR_ATTR_REQ, &b64_len);
 	if (!b64)
 		return NULL;
-	return base64_decode((const char *) b64, b64_len, len);
+	return hostap_base64_decode((const char *) b64, b64_len, len);
 }
 #endif /* CONFIG_DPP2 */
 

--- a/src/common/dpp_crypto.c
+++ b/src/common/dpp_crypto.c
@@ -342,7 +342,7 @@ int dpp_keygen(struct dpp_bootstrap_info *bi, const char *curve,
 		goto fail;
 	}
 
-	base64 = base64_encode(wpabuf_head(der), wpabuf_len(der), &len);
+	base64 = hostap_base64_encode(wpabuf_head(der), wpabuf_len(der), &len);
 	wpabuf_free(der);
 	der = NULL;
 	if (!base64)
@@ -2158,7 +2158,7 @@ int dpp_validate_csr(struct dpp_authentication *auth,
 		goto fail;
 	}
 
-	cp = base64_decode((const char *) attr, attr_len, &cp_len);
+	cp = hostap_base64_decode((const char *) attr, attr_len, &cp_len);
 	if (!cp) {
 		wpa_printf(MSG_DEBUG,
 			   "DPP: Could not base64 decode challengePassword");

--- a/src/common/sae_pk.c
+++ b/src/common/sae_pk.c
@@ -488,7 +488,7 @@ struct sae_pk * sae_parse_pk(const char *val)
 		pos2++;
 	}
 #endif /* CONFIG_TESTING_OPTIONS */
-	der = base64_decode(pos, b_len, &der_len);
+	der = hostap_base64_decode(pos, b_len, &der_len);
 	if (!der) {
 		wpa_printf(MSG_INFO, "SAE: Failed to base64 decode PK key");
 		goto fail;
@@ -505,7 +505,7 @@ struct sae_pk * sae_parse_pk(const char *val)
 
 #ifdef CONFIG_TESTING_OPTIONS
 	if (pos2) {
-		der = base64_decode(pos2, os_strlen(pos2), &der_len);
+		der = hostap_base64_decode(pos2, os_strlen(pos2), &der_len);
 		if (!der) {
 			wpa_printf(MSG_INFO,
 				   "SAE: Failed to base64 decode PK key");

--- a/src/eap_peer/tncc.c
+++ b/src/eap_peer/tncc.c
@@ -156,7 +156,7 @@ static TNC_Result TNC_TNCC_SendMessage(
 	if (imcID >= TNC_MAX_IMC_ID || tnc_imc[imcID] == NULL)
 		return TNC_RESULT_INVALID_PARAMETER;
 
-	b64 = base64_encode(message, messageLength, &b64len);
+	b64 = hostap_base64_encode(message, messageLength, &b64len);
 	if (b64 == NULL)
 		return TNC_RESULT_FATAL;
 
@@ -629,7 +629,7 @@ static unsigned char * tncc_get_base64(char *start, size_t *decoded_len)
 		return NULL;
 	*pos2 = '\0';
 
-	decoded = base64_decode(pos, os_strlen(pos), decoded_len);
+	decoded = hostap_base64_decode(pos, os_strlen(pos), decoded_len);
 	*pos2 = '<';
 	if (decoded == NULL) {
 		wpa_printf(MSG_DEBUG, "TNC: Failed to decode Base64 data");

--- a/src/eap_server/tncs.c
+++ b/src/eap_server/tncs.c
@@ -195,7 +195,7 @@ static TNC_Result TNC_TNCS_SendMessage(
 	if (tncs == NULL)
 		return TNC_RESULT_INVALID_PARAMETER;
 
-	b64 = base64_encode(message, messageLength, &b64len);
+	b64 = hostap_base64_encode(message, messageLength, &b64len);
 	if (b64 == NULL)
 		return TNC_RESULT_FATAL;
 
@@ -678,7 +678,7 @@ static unsigned char * tncs_get_base64(char *start, size_t *decoded_len)
 		return NULL;
 	*pos2 = '\0';
 
-	decoded = base64_decode(pos, os_strlen(pos), decoded_len);
+	decoded = hostap_base64_decode(pos, os_strlen(pos), decoded_len);
 	*pos2 = '<';
 	if (decoded == NULL) {
 		wpa_printf(MSG_DEBUG, "TNC: Failed to decode Base64 data");

--- a/src/tls/tlsv1_cred.c
+++ b/src/tls/tlsv1_cred.c
@@ -130,7 +130,7 @@ static int tlsv1_add_cert(struct x509_certificate **chain,
 			return -1;
 		}
 
-		der = base64_decode((const char *) pos, end - pos, &der_len);
+		der = hostap_base64_decode((const char *) pos, end - pos, &der_len);
 		if (der == NULL) {
 			wpa_printf(MSG_INFO, "TLSv1: Could not decode PEM "
 				   "certificate");
@@ -293,7 +293,7 @@ static struct crypto_private_key * tlsv1_set_key_pem(const u8 *key, size_t len)
 		}
 	}
 
-	der = base64_decode((const char *) pos, end - pos, &der_len);
+	der = hostap_base64_decode((const char *) pos, end - pos, &der_len);
 	if (!der)
 		return NULL;
 	pkey = crypto_private_key_import(der, der_len, NULL);
@@ -321,7 +321,7 @@ static struct crypto_private_key * tlsv1_set_key_enc_pem(const u8 *key,
 	if (!end)
 		return NULL;
 
-	der = base64_decode((const char *) pos, end - pos, &der_len);
+	der = hostap_base64_decode((const char *) pos, end - pos, &der_len);
 	if (!der)
 		return NULL;
 	pkey = crypto_private_key_import(der, der_len, passwd);
@@ -1158,7 +1158,7 @@ static int tlsv1_set_dhparams_blob(struct tlsv1_credentials *cred,
 		return -1;
 	}
 
-	der = base64_decode((const char *) pos, end - pos, &der_len);
+	der = hostap_base64_decode((const char *) pos, end - pos, &der_len);
 	if (der == NULL) {
 		wpa_printf(MSG_INFO, "TLSv1: Could not decode PEM dhparams");
 		return -1;

--- a/src/utils/base64.c
+++ b/src/utils/base64.c
@@ -156,7 +156,7 @@ static unsigned char * base64_gen_decode(const char *src, size_t len,
 
 
 /**
- * base64_encode - Base64 encode
+ * hostap_base64_encode - Base64 encode
  * @src: Data to be encoded
  * @len: Length of the data to be encoded
  * @out_len: Pointer to output length variable, or %NULL if not used
@@ -167,7 +167,7 @@ static unsigned char * base64_gen_decode(const char *src, size_t len,
  * nul terminated to make it easier to use as a C string. The nul terminator is
  * not included in out_len.
  */
-char * base64_encode(const void *src, size_t len, size_t *out_len)
+char * hostap_base64_encode(const void *src, size_t len, size_t *out_len)
 {
 	return base64_gen_encode(src, len, out_len, base64_table,
 				 BASE64_PAD | BASE64_LF);
@@ -187,7 +187,7 @@ char * base64_url_encode(const void *src, size_t len, size_t *out_len)
 
 
 /**
- * base64_decode - Base64 decode
+ * hostap_base64_decode - Base64 decode
  * @src: Data to be decoded
  * @len: Length of the data to be decoded
  * @out_len: Pointer to output length variable
@@ -196,7 +196,7 @@ char * base64_url_encode(const void *src, size_t len, size_t *out_len)
  *
  * Caller is responsible for freeing the returned buffer.
  */
-unsigned char * base64_decode(const char *src, size_t len, size_t *out_len)
+unsigned char * hostap_base64_decode(const char *src, size_t len, size_t *out_len)
 {
 	return base64_gen_decode(src, len, out_len, base64_table);
 }

--- a/src/utils/base64.h
+++ b/src/utils/base64.h
@@ -9,9 +9,9 @@
 #ifndef BASE64_H
 #define BASE64_H
 
-char * base64_encode(const void *src, size_t len, size_t *out_len);
+char * hostap_base64_encode(const void *src, size_t len, size_t *out_len);
 char * base64_encode_no_lf(const void *src, size_t len, size_t *out_len);
-unsigned char * base64_decode(const char *src, size_t len, size_t *out_len);
+unsigned char * hostap_base64_decode(const char *src, size_t len, size_t *out_len);
 char * base64_url_encode(const void *src, size_t len, size_t *out_len);
 unsigned char * base64_url_decode(const char *src, size_t len, size_t *out_len);
 

--- a/src/utils/json.c
+++ b/src/utils/json.c
@@ -539,7 +539,7 @@ struct wpabuf * json_get_member_base64(struct json_token *json,
 	token = json_get_member(json, name);
 	if (!token || token->type != JSON_STRING)
 		return NULL;
-	buf = base64_decode(token->string, os_strlen(token->string), &buflen);
+	buf = hostap_base64_decode(token->string, os_strlen(token->string), &buflen);
 	if (!buf)
 		return NULL;
 	ret = wpabuf_alloc_ext_data(buf, buflen);

--- a/src/utils/utils_module_tests.c
+++ b/src/utils/utils_module_tests.c
@@ -301,48 +301,48 @@ static int base64_tests(void)
 
 	wpa_printf(MSG_INFO, "base64 tests");
 
-	res2 = base64_encode("", ~0, &res_len);
+	res2 = hostap_base64_encode("", ~0, &res_len);
 	if (res2) {
 		errors++;
 		os_free(res2);
 	}
 
-	res2 = base64_encode("=", 1, &res_len);
+	res2 = hostap_base64_encode("=", 1, &res_len);
 	if (!res2 || res_len != 5 || res2[0] != 'P' || res2[1] != 'Q' ||
 	    res2[2] != '=' || res2[3] != '=' || res2[4] != '\n')
 		errors++;
 	os_free(res2);
 
-	res2 = base64_encode("=", 1, NULL);
+	res2 = hostap_base64_encode("=", 1, NULL);
 	if (!res2 || res2[0] != 'P' || res2[1] != 'Q' ||
 	    res2[2] != '=' || res2[3] != '=' || res2[4] != '\n')
 		errors++;
 	os_free(res2);
 
-	res = base64_decode("", 0, &res_len);
+	res = hostap_base64_decode("", 0, &res_len);
 	if (res) {
 		errors++;
 		os_free(res);
 	}
 
-	res = base64_decode("a", 1, &res_len);
+	res = hostap_base64_decode("a", 1, &res_len);
 	if (res) {
 		errors++;
 		os_free(res);
 	}
 
-	res = base64_decode("====", 4, &res_len);
+	res = hostap_base64_decode("====", 4, &res_len);
 	if (res) {
 		errors++;
 		os_free(res);
 	}
 
-	res = base64_decode("PQ==", 4, &res_len);
+	res = hostap_base64_decode("PQ==", 4, &res_len);
 	if (!res || res_len != 1 || res[0] != '=')
 		errors++;
 	os_free(res);
 
-	res = base64_decode("P.Q-=!=*", 8, &res_len);
+	res = hostap_base64_decode("P.Q-=!=*", 8, &res_len);
 	if (!res || res_len != 1 || res[0] != '=')
 		errors++;
 	os_free(res);

--- a/src/utils/xml_libxml2.c
+++ b/src/utils/xml_libxml2.c
@@ -409,7 +409,7 @@ char * xml_node_get_base64_text(struct xml_node_ctx *ctx, xml_node_t *node,
 	if (txt == NULL)
 		return NULL;
 
-	ret = base64_decode(txt, strlen(txt), &len);
+	ret = hostap_base64_decode(txt, strlen(txt), &len);
 	if (ret_len)
 		*ret_len = len;
 	xml_node_get_text_free(ctx, txt);

--- a/src/wps/upnp_xml.c
+++ b/src/wps/upnp_xml.c
@@ -235,7 +235,7 @@ struct wpabuf * xml_get_base64_item(const char *data, const char *name,
 		return NULL;
 	}
 
-	decoded = base64_decode(msg, os_strlen(msg), &len);
+	decoded = hostap_base64_decode(msg, os_strlen(msg), &len);
 	os_free(msg);
 	if (decoded == NULL) {
 		*ret = UPNP_OUT_OF_MEMORY;

--- a/src/wps/wps_er.c
+++ b/src/wps/wps_er.c
@@ -902,8 +902,8 @@ static struct wpabuf * wps_er_soap_hdr(const struct wpabuf *msg,
 	struct wpabuf *buf;
 
 	if (msg) {
-		encoded = base64_encode(wpabuf_head(msg), wpabuf_len(msg),
-					&encoded_len);
+		encoded = hostap_base64_encode(wpabuf_head(msg), wpabuf_len(msg),
+					       &encoded_len);
 		if (encoded == NULL)
 			return NULL;
 	} else {

--- a/src/wps/wps_registrar.c
+++ b/src/wps/wps_registrar.c
@@ -1729,8 +1729,8 @@ int wps_build_cred(struct wps_data *wps, struct wpabuf *msg)
 			return -1;
 		}
 		os_free(wps->new_psk);
-		wps->new_psk = (u8 *) base64_encode(r, sizeof(r),
-						    &wps->new_psk_len);
+		wps->new_psk = (u8 *) hostap_base64_encode(r, sizeof(r),
+							   &wps->new_psk_len);
 		if (wps->new_psk == NULL)
 			return -1;
 		wps->new_psk_len--; /* remove newline */

--- a/src/wps/wps_upnp.c
+++ b/src/wps/wps_upnp.c
@@ -670,8 +670,8 @@ static int subscription_first_event(struct subscription *s)
 		msg = build_fake_wsc_ack();
 		if (msg) {
 			s->sm->wlanevent =
-				base64_encode(wpabuf_head(msg),
-					      wpabuf_len(msg), NULL);
+				hostap_base64_encode(wpabuf_head(msg),
+						     wpabuf_len(msg), NULL);
 			wpabuf_free(msg);
 		}
 	}
@@ -844,7 +844,7 @@ int upnp_wps_device_send_wlan_event(struct upnp_wps_device_sm *sm,
 	}
 	raw_len = pos;
 
-	val = base64_encode(raw, raw_len, &val_len);
+	val = hostap_base64_encode(raw, raw_len, &val_len);
 	if (val == NULL)
 		goto fail;
 

--- a/src/wps/wps_upnp_web.c
+++ b/src/wps/wps_upnp_web.c
@@ -765,8 +765,8 @@ static void web_connection_send_reply(struct http_request *req,
 
 	if (reply) {
 		size_t len;
-		replydata = base64_encode(wpabuf_head(reply), wpabuf_len(reply),
-					  &len);
+		replydata = hostap_base64_encode(wpabuf_head(reply), wpabuf_len(reply),
+						 &len);
 	} else
 		replydata = NULL;
 

--- a/tests/hwsim/test_ap_wps.py
+++ b/tests/hwsim/test_ap_wps.py
@@ -3450,7 +3450,7 @@ def test_ap_wps_upnp_subscribe(dev, apdev):
         time.sleep(0.1)
 
     with alloc_fail(hapd, 1,
-                    "base64_gen_encode;?base64_encode;upnp_wps_device_send_wlan_event"):
+                    "base64_gen_encode;?hostap_base64_encode;upnp_wps_device_send_wlan_event"):
         dev[1].dump_monitor()
         dev[1].request("WPS_PIN " + apdev[0]['bssid'] + " 12345670")
         dev[1].wait_event(["CTRL-EVENT-SCAN-RESULTS"], 5)
@@ -4000,7 +4000,7 @@ def test_ap_wps_init_oom(dev, apdev):
     params = {"ssid": ssid, "eap_server": "1", "wps_state": "1"}
     hapd = hostapd.add_ap(apdev[0], params)
 
-    with alloc_fail(hapd, 1, "base64_gen_encode;?base64_encode;wps_build_cred"):
+    with alloc_fail(hapd, 1, "base64_gen_encode;?hostap_base64_encode;wps_build_cred"):
         pin = dev[0].wps_read_pin()
         hapd.request("WPS_PIN any " + pin)
         dev[0].scan_for_bss(apdev[0]['bssid'], freq="2412")
@@ -4038,7 +4038,7 @@ def _test_ap_wps_er_oom(dev, apdev):
     dev[0].connect(ssid, psk="12345678", scan_freq="2412")
 
     with alloc_fail(dev[0], 1,
-                    "base64_gen_decode;?base64_decode;xml_get_base64_item"):
+                    "base64_gen_decode;?hostap_base64_decode;xml_get_base64_item"):
         dev[0].request("WPS_ER_START ifname=lo")
         ev = dev[0].wait_event(["WPS-ER-AP-ADD"], timeout=3)
         if ev is not None:
@@ -4052,7 +4052,7 @@ def _test_ap_wps_er_oom(dev, apdev):
 
     dev[1].scan_for_bss(apdev[0]['bssid'], freq=2412)
     with alloc_fail(dev[0], 1,
-                    "base64_gen_decode;?base64_decode;xml_get_base64_item"):
+                    "base64_gen_decode;?hostap_base64_decode;xml_get_base64_item"):
         dev[1].request("WPS_PBC " + apdev[0]['bssid'])
         ev = dev[1].wait_event(["CTRL-EVENT-SCAN-RESULTS"], timeout=10)
         if ev is None:
@@ -4865,7 +4865,7 @@ RGV2aWNlIEEQSQAGADcqAAEg
         raise Exception("Enrollee add event not seen")
 
     with alloc_fail(dev[0], 1,
-                    "base64_gen_encode;?base64_encode;wps_er_soap_hdr"):
+                    "base64_gen_encode;?hostap_base64_encode;wps_er_soap_hdr"):
         send_wlanevent(url, uuid, data)
 
     with alloc_fail(dev[0], 1, "wpabuf_alloc;wps_er_soap_hdr"):

--- a/tests/hwsim/test_tnc.py
+++ b/tests/hwsim/test_tnc.py
@@ -146,7 +146,7 @@ def test_tnc_ttls_errors(dev, apdev):
              (1, "os_readfile;tncc_read_config", "pap user", "auth=PAP"),
              (1, "tncc_init", "pap user", "auth=PAP"),
              (1, "TNC_TNCC_ReportMessageTypes", "pap user", "auth=PAP"),
-             (1, "base64_gen_encode;?base64_encode;TNC_TNCC_SendMessage",
+             (1, "base64_gen_encode;?hostap_base64_encode;TNC_TNCC_SendMessage",
               "pap user", "auth=PAP"),
              (1, "=TNC_TNCC_SendMessage", "pap user", "auth=PAP"),
              (1, "tncc_get_base64;tncc_process_if_tnccs",

--- a/tests/test-base64.c
+++ b/tests/test-base64.c
@@ -26,9 +26,9 @@ int main(int argc, char *argv[])
 		return -1;
 
 	if (strcmp(argv[1], "encode") == 0)
-		e = (unsigned char *) base64_encode(buf, len, &elen);
+		e = (unsigned char *) hostap_base64_encode(buf, len, &elen);
 	else
-		e = base64_decode((const char *) buf, len, &elen);
+		e = hostap_base64_decode((const char *) buf, len, &elen);
 	if (e == NULL)
 		return -2;
 	f = fopen(argv[3], "w");

--- a/wpa_supplicant/config_file.c
+++ b/wpa_supplicant/config_file.c
@@ -251,7 +251,7 @@ static struct wpa_config_blob * wpa_config_read_blob(FILE *f, int *line,
 		return NULL;
 	}
 	blob->name = os_strdup(name);
-	blob->data = base64_decode(encoded, encoded_len, &blob->len);
+	blob->data = hostap_base64_decode(encoded, encoded_len, &blob->len);
 	os_free(encoded);
 
 	if (blob->name == NULL || blob->data == NULL) {
@@ -1047,7 +1047,7 @@ static int wpa_config_write_blob(FILE *f, struct wpa_config_blob *blob)
 {
 	char *encoded;
 
-	encoded = base64_encode(blob->data, blob->len, NULL);
+	encoded = hostap_base64_encode(blob->data, blob->len, NULL);
 	if (encoded == NULL)
 		return -1;
 

--- a/wpa_supplicant/dpp_supplicant.c
+++ b/wpa_supplicant/dpp_supplicant.c
@@ -4422,7 +4422,7 @@ int wpas_dpp_ca_set(struct wpa_supplicant *wpa_s, const char *cmd)
 		return auth->trusted_eap_server_name ? 0 : -1;
 	}
 
-	bin = base64_decode(value, os_strlen(value), &bin_len);
+	bin = hostap_base64_decode(value, os_strlen(value), &bin_len);
 	if (!bin)
 		return -1;
 	buf = wpabuf_alloc_copy(bin, bin_len);

--- a/wpa_supplicant/eapol_test.c
+++ b/wpa_supplicant/eapol_test.c
@@ -441,7 +441,7 @@ static void eapol_test_write_cert(FILE *f, const char *subject,
 {
 	char *encoded;
 
-	encoded = base64_encode(wpabuf_head(cert), wpabuf_len(cert), NULL);
+	encoded = hostap_base64_encode(wpabuf_head(cert), wpabuf_len(cert), NULL);
 	if (encoded == NULL)
 		return;
 	fprintf(f, "%s\n-----BEGIN CERTIFICATE-----\n%s"

--- a/wpa_supplicant/hs20_supplicant.c
+++ b/wpa_supplicant/hs20_supplicant.c
@@ -360,7 +360,7 @@ int hs20_get_icon(struct wpa_supplicant *wpa_s, const u8 *bssid,
 	if (size == 0)
 		return -1;
 
-	b64 = base64_encode(&icon->image[offset], size, &b64_size);
+	b64 = hostap_base64_encode(&icon->image[offset], size, &b64_size);
 	if (b64 && buf_len >= b64_size) {
 		os_memcpy(reply, b64, b64_size);
 		reply_size = b64_size;


### PR DESCRIPTION
Zephyr provides own base64 library with the same function names as hostap. Because of this, it's not possible to build applications enabling both supplicant and CONFIG_BASE64. As Zephyr takes preference here, we need to rename the colliding functions in hostap.