### PR TITLE
zephyr: udp throughput fail when legacy roaming

### DIFF
--- a/src/drivers/driver_zephyr.h
+++ b/src/drivers/driver_zephyr.h
@@ -138,6 +138,7 @@ struct zep_drv_if_ctx {
 	bool scan_res2_get_in_prog;
 
 	bool ft_roaming;
+	bool roaming;
 
 	unsigned int freq;
 	unsigned char ssid[SSID_MAX_LEN];


### PR DESCRIPTION
udp tx throughput fail is expected, legacy roaming triggered dhcp will change ip address, but udp tx throughput specify fixed ip address during udp tx iperf, so udp tx throughput fail after dhcp. Using assoc_freq in wps_supplicant to get current connect state. if assoc_freq is not zero, sta is connected, and we think it is in roaming when auth. doesn't restart dhcp. and ecsa also doesn't restart dhcp.