### PR TITLE
zephyr: modify log type from info to debug

### DIFF
--- a/hostapd/hostapd_cli_zephyr.c
+++ b/hostapd/hostapd_cli_zephyr.c
@@ -269,7 +269,7 @@ static void hostapd_cli_recv_pending(struct wpa_ctrl *ctrl, struct hostapd_data 
 			wpa_printf(MSG_DEBUG, "Received len: %d, msg_len:%d - %s->END\n",
 				   plen, msg->msg_len, msg->msg);
 			if (msg->msg_len >= MAX_CTRL_MSG_LEN) {
-				wpa_printf(MSG_INFO, "Too long message received.\n");
+				wpa_printf(MSG_DEBUG, "Too long message received.\n");
 				continue;
 			}
 


### PR DESCRIPTION
print too long msg when eap enterprise.
we should not print the log, so set print type to debug.