### PR TITLE
[toup] zephyr: fix build error of inet_aton

### DIFF
--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -558,6 +558,7 @@ static inline int is_multicast_ether_addr(const u8 *a)
 
 #if defined(__ZEPHYR__)
 #include "wpa_debug_zephyr.h"
+#define inet_aton(cp, addr) inet_pton(AF_INET, cp, (char *)addr)
 #else
 #include "wpa_debug.h"
 #endif


### PR DESCRIPTION
Fix build error of undefined reference to 'inet_aton' in hostap/src/utils/ip_addr.c