### PR TITLE
[toup] crypto: remove the include of fsl_debug_console.h

### DIFF
--- a/src/crypto/tls_mbedtls_alt.c
+++ b/src/crypto/tls_mbedtls_alt.c
@@ -64,8 +64,6 @@
 #include <mbedtls/debug.h>
 #ifdef __ZEPHYR__
 #define PRINTF printk
-#else
-#include "fsl_debug_console.h"
 #endif
 #define tls_mbedtls_d(...) PRINTF("tls_mbedtls", ##__VA_ARGS__)
 #else


### PR DESCRIPTION
Remove the include of fsl_debug_console.h, which is not used for Zephyr