### PR TITLE
[noup] wpa_ctrl: Add a config option for WPA control timeout

### DIFF
--- a/src/common/wpa_ctrl.c
+++ b/src/common/wpa_ctrl.c
@@ -548,7 +548,7 @@ retry_send:
 	os_free(cmd_buf);
 
 	for (;;) {
-		tv.tv_sec = 10;
+		tv.tv_sec = CONFIG_WIFI_NM_WPA_CTRL_RESP_TIMEOUT_S;
 		tv.tv_usec = 0;
 		FD_ZERO(&rfds);
 		FD_SET(ctrl->s, &rfds);


### PR DESCRIPTION
WPA control interface timeout is hardcoded to 10s, use the newly introduced configuration option, this is needed sometimes as a workaround e.g., crypto taking too long to complete the request.

Work around for #79834.

Note: Though a generic change, this is marked as `noup` because typically 10s timeout is plenty and I don't think an extra config option would be welcomed :).