### PR TITLE
zephyr: udp throughput fail when legacy roaming

### DIFF
--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -538,6 +538,9 @@ void wpa_drv_zep_event_proc_assoc_resp(struct zep_drv_if_ctx *if_ctx,
 		if (if_ctx->ft_roaming) {
 			if_ctx->ft_roaming = false;
 		}
+		if (if_ctx->roaming) {
+		    if_ctx->roaming = false;
+		}
 		wpa_supplicant_event_wrapper(if_ctx->supp_if_ctx,
 				EVENT_ASSOC_REJECT,
 				event);
@@ -1549,6 +1552,10 @@ static int wpa_drv_zep_deauthenticate(void *priv, const u8 *addr,
 		if_ctx->ft_roaming = false;
 	}
 
+	if (if_ctx->roaming) {
+		if_ctx->roaming = false;
+	}
+
 	dev_ops = get_dev_ops(if_ctx->dev_ctx);
 	ret = dev_ops->deauthenticate(if_ctx->dev_priv, addr, reason_code);
 	if (ret) {
@@ -1569,6 +1576,7 @@ static int wpa_drv_zep_authenticate(void *priv,
 	const struct zep_wpa_supp_dev_ops *dev_ops;
 	struct wpa_bss *curr_bss;
 	int ret = -1;
+	struct wpa_supplicant *wpa_s = NULL;
 
 	if ((!priv) || (!params)) {
 		wpa_printf(MSG_ERROR, "%s: Invalid params", __func__);
@@ -1576,11 +1584,16 @@ static int wpa_drv_zep_authenticate(void *priv,
 	}
 
 	if_ctx = priv;
-
+	wpa_s = if_ctx->supp_if_ctx;
 	if_ctx->ft_roaming = false;
+	if_ctx->roaming = false;
 
 	if (params->auth_alg == WPA_AUTH_ALG_FT) {
 		if_ctx->ft_roaming = true;
+	}
+
+	if (wpa_s->assoc_freq) {
+		if_ctx->roaming = true;
 	}
 
 	dev_ops = get_dev_ops(if_ctx->dev_ctx);
@@ -1833,10 +1846,11 @@ static int wpa_drv_zep_set_supp_port(void *priv,
 #ifdef CONFIG_NET_DHCPV4
 	if (authorized) {
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_SKIP_DHCP_ON_ROAMING
-		if (if_ctx->ft_roaming == false) {
-			net_dhcpv4_restart(iface);
-		} else {
+		if (if_ctx->ft_roaming == true || if_ctx->roaming == true) {
+			if_ctx->roaming = false;
 			if_ctx->ft_roaming = false;
+		} else {
+			net_dhcpv4_restart(iface);
 		}
 #else
 		net_dhcpv4_restart(iface);

--- a/src/drivers/driver_zephyr.h
+++ b/src/drivers/driver_zephyr.h
@@ -138,6 +138,7 @@ struct zep_drv_if_ctx {
 	bool scan_res2_get_in_prog;
 
 	bool ft_roaming;
+	bool roaming;
 
 	unsigned int freq;
 	unsigned char ssid[SSID_MAX_LEN];


### PR DESCRIPTION
zperf udp tx throughput uses fixed ip address, if run legacy roaming at
this time, roaming will restart dhcp and ip address is changed,
so zperf can't find ip address when zperf send udp packet during legacy
roaming, and zperf udp tx fail.
we think that legacy roaming shouldn't restart dhcp, so we need to
determine whether current connection is a normal connection or a
roaming, and determine whether we should restart dhcp.
and we use assoc_freq parameter in wps_supplicant to get current connect
state.
if assoc_freq is not 0, it indicates that the sta already connects, and
current connection is roaming, so we doesn't start dhcp.
if assoc_freq is 0, it indicates that current connection is a normal
connection rather than roaming, so we want to start dhcp.