### PR TITLE
A few trivial fixes to build warnings on 64bit targets

### DIFF
--- a/hostapd/hostapd_cli_zephyr.c
+++ b/hostapd/hostapd_cli_zephyr.c
@@ -126,7 +126,7 @@ static char make_argv(char **ppcmd, uint8_t c)
 	return quote;
 }
 
-char hostapd_make_argv(size_t *argc, const char **argv, char *cmd,
+static char hostapd_make_argv(int *argc, const char **argv, char *cmd,
 		       uint8_t max_argc)
 {
 	char quote = 0;
@@ -258,7 +258,7 @@ static void hostapd_cli_recv_pending(struct wpa_ctrl *ctrl, struct hostapd_data 
 		    hlen == sizeof(int)) {
 			plen = *((int *)buf);
 		} else {
-			wpa_printf(MSG_ERROR, "Could not read pending message header len %d.\n", hlen);
+			wpa_printf(MSG_ERROR, "Could not read pending message header len %zu.\n", hlen);
 			continue;
 		}
 
@@ -266,7 +266,7 @@ static void hostapd_cli_recv_pending(struct wpa_ctrl *ctrl, struct hostapd_data 
 			struct conn_msg *msg = (struct conn_msg *)buf;
 
 			msg->msg[msg->msg_len] = '\0';
-			wpa_printf(MSG_DEBUG, "Received len: %d, msg_len:%d - %s->END\n",
+			wpa_printf(MSG_DEBUG, "Received len: %zu, msg_len:%d - %s->END\n",
 				   plen, msg->msg_len, msg->msg);
 			if (msg->msg_len >= MAX_CTRL_MSG_LEN) {
 				wpa_printf(MSG_INFO, "Too long message received.\n");

--- a/src/ap/ap_drv_ops.c
+++ b/src/ap/ap_drv_ops.c
@@ -269,7 +269,7 @@ int hostapd_set_authorized(struct hostapd_data *hapd,
 
 	return hostapd_sta_set_flags(hapd, sta->addr,
 				     hostapd_sta_flags_to_drv(sta->flags),
-				     0, ~WPA_STA_AUTHORIZED);
+				     0, ~(int)WPA_STA_AUTHORIZED);
 }
 
 

--- a/src/common/wpa_ctrl.c
+++ b/src/common/wpa_ctrl.c
@@ -599,7 +599,7 @@ struct wpa_ctrl * wpa_ctrl_open(const int sock)
 
 	ctrl = os_zalloc(sizeof(*ctrl));
 	if (ctrl == NULL) {
-		wpa_printf(MSG_ERROR, "Failed to allocate memory: %d\n", sizeof(*ctrl));
+		wpa_printf(MSG_ERROR, "Failed to allocate memory: %zu\n", sizeof(*ctrl));
 		return NULL;
 	}
 

--- a/src/crypto/crypto_mbedtls-ec.c
+++ b/src/crypto/crypto_mbedtls-ec.c
@@ -743,7 +743,7 @@ int crypto_ecdh(
 
 	if (*secret_len > DPP_MAX_SHARED_SECRET_LEN) {
 		wpa_printf(
-		    MSG_ERROR, "secret len=%d is too big\n", *secret_len);
+		    MSG_ERROR, "secret len=%zu is too big\n", *secret_len);
 		goto fail;
 	}
 

--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -59,7 +59,7 @@ void hostapd_event_wrapper(void *ctx, enum wpa_event_type event, union wpa_event
 				char *frame = os_zalloc(data->tx_status.data_len);
 
 				if (!frame) {
-					wpa_printf(MSG_ERROR, "%s:%d Failed to alloc %d bytes\n", __func__,
+					wpa_printf(MSG_ERROR, "%s:%d Failed to alloc %zu bytes\n", __func__,
 								__LINE__, data->tx_status.data_len);
 					os_free(msg.data);
 					return;
@@ -77,7 +77,7 @@ void hostapd_event_wrapper(void *ctx, enum wpa_event_type event, union wpa_event
 				char *frame = os_zalloc(data->rx_mgmt.frame_len);
 
 				if (!frame) {
-					wpa_printf(MSG_ERROR, "%s:%d Failed to alloc %d bytes\n",
+					wpa_printf(MSG_ERROR, "%s:%d Failed to alloc %zu bytes\n",
 						__func__, __LINE__, data->rx_mgmt.frame_len);
 					os_free(msg.data);
 					return;
@@ -116,7 +116,7 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!ies) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d event %u Failed to alloc ies %d bytes\n",
+					  "%s:%d event %u Failed to alloc ies %zu bytes\n",
 					  __func__, __LINE__, event, data->auth.ies_len);
 					os_free(msg.data);
 					return;
@@ -133,7 +133,7 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!frame) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d event %u Failed to alloc frame %d bytes\n",
+					  "%s:%d event %u Failed to alloc frame %zu bytes\n",
 					  __func__, __LINE__, event, data->rx_mgmt.frame_len);
 					os_free(msg.data);
 					return;
@@ -151,7 +151,7 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!frame) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d event %u Failed to alloc frame %d bytes\n",
+					  "%s:%d event %u Failed to alloc frame %zu bytes\n",
 					  __func__, __LINE__, event, data->tx_status.data_len);
 					os_free(msg.data);
 					return;
@@ -182,7 +182,7 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!req_ies) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d event %u Failed to alloc req_ies %d bytes\n",
+					  "%s:%d event %u Failed to alloc req_ies %zu bytes\n",
 					  __func__, __LINE__, event, data->assoc_info.req_ies_len);
 					os_free(msg.data);
 					os_free(addr);
@@ -198,7 +198,7 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!resp_ies) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d event %u Failed to alloc resp_ies %d bytes\n",
+					  "%s:%d event %u Failed to alloc resp_ies %zu bytes\n",
 					  __func__, __LINE__, event, data->assoc_info.resp_ies_len);
 					os_free(msg.data);
 					os_free(addr);
@@ -216,7 +216,7 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!resp_frame) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d event %u Failed to alloc resp_frame %d bytes\n",
+					  "%s:%d event %u Failed to alloc resp_frame %zu bytes\n",
 					  __func__, __LINE__, event, data->assoc_info.resp_frame_len);
 					os_free(msg.data);
 					os_free(addr);
@@ -251,7 +251,7 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!resp_ies) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d event %u Failed to alloc resp_ies %d bytes\n",
+					  "%s:%d event %u Failed to alloc resp_ies %zu bytes\n",
 					  __func__, __LINE__,  event, data->assoc_reject.resp_ies_len);
 					os_free(msg.data);
 					os_free(bssid);
@@ -281,7 +281,7 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!ie) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d event %u Failed to alloc ie %d bytes\n",
+					  "%s:%d event %u Failed to alloc ie %zu bytes\n",
 					  __func__, __LINE__,  event, data->deauth_info.ie_len);
 					os_free(msg.data);
 					os_free(sa);
@@ -310,7 +310,7 @@ void wpa_supplicant_event_wrapper(void *ctx,
 
 				if (!ie) {
 					wpa_printf(MSG_ERROR,
-					  "%s:%d event %u Failed to alloc ie %d bytes\n",
+					  "%s:%d event %u Failed to alloc ie %zu bytes\n",
 					  __func__, __LINE__,  event, data->disassoc_info.ie_len);
 					os_free(msg.data);
 					os_free(sa);
@@ -502,7 +502,7 @@ void wpa_drv_zep_event_proc_scan_res(struct zep_drv_if_ctx *if_ctx,
 
 	struct wpa_scan_res *sr = os_zalloc(scan_res_len);
 	if (!sr) {
-		wpa_printf(MSG_ERROR, "%s: Failed to alloc scan results(%d bytes)", __func__, scan_res_len);
+		wpa_printf(MSG_ERROR, "%s: Failed to alloc scan results(%zu bytes)", __func__, scan_res_len);
 		if_ctx->scan_res2->res = tmp;
 		goto err;
 	}
@@ -1698,7 +1698,7 @@ static int _wpa_drv_zep_set_key(void *priv,
 	}
 
 	wpa_printf(MSG_DEBUG, "%s: priv:%p alg %d addr %p key_idx %d set_tx %d seq %p "
-		   "seq_len %d key %p key_len %d key_flag %x",
+		   "seq_len %zu key %p key_len %zu key_flag %x",
 		   __func__,
 		   if_ctx->dev_priv,
 		   alg, addr,
@@ -1801,7 +1801,7 @@ static int wpa_drv_zep_get_ssid(void *priv,
 	if_ctx = priv;
 
 	wpa_printf(MSG_DEBUG,
-		   "%s: SSID size: %d",
+		   "%s: SSID size: %zu",
 		   __func__,
 		   if_ctx->ssid_len);
 

--- a/wpa_supplicant/wpa_cli_zephyr.c
+++ b/wpa_supplicant/wpa_cli_zephyr.c
@@ -134,7 +134,7 @@ static void wpa_cli_recv_pending(struct wpa_ctrl *ctrl, struct wpa_supplicant *w
 		    hlen == sizeof(int)) {
 			plen = *((int *)buf);
 		} else {
-			wpa_printf(MSG_ERROR, "Could not read pending message header len %d.\n", hlen);
+			wpa_printf(MSG_ERROR, "Could not read pending message header len %zu\n", hlen);
 			continue;
 		}
 
@@ -142,7 +142,7 @@ static void wpa_cli_recv_pending(struct wpa_ctrl *ctrl, struct wpa_supplicant *w
 			struct conn_msg *msg = (struct conn_msg *)buf;
 
 			msg->msg[msg->msg_len] = '\0';
-			wpa_printf(MSG_DEBUG, "Received len: %d, msg_len:%d - %s->END\n",
+			wpa_printf(MSG_DEBUG, "Received len: %zu, msg_len:%d - %s->END\n",
 				   plen, msg->msg_len, msg->msg);
 			if (msg->msg_len >= MAX_CTRL_MSG_LEN) {
 				wpa_printf(MSG_DEBUG, "Too long message received.\n");
@@ -333,7 +333,7 @@ static char make_argv(char **ppcmd, uint8_t c)
 }
 
 
-char supp_make_argv(size_t *argc, const char **argv, char *cmd,
+static char supp_make_argv(int *argc, const char **argv, char *cmd,
 		       uint8_t max_argc)
 {
 	char quote = 0;


### PR DESCRIPTION
I have no clue how you guys are handling this fork, if you want me to add some tag to the commit titles or so just tell.
You are also welcome to modify the commits or do anything with them as you please.

    Fix multiple size_t print format specifiers
    
    The format specifier for size_t is zu.
    Using d only works when int and size_t are the same
    underlying type which is not the case for 64bit systems,
    which leads to a build warning in this case.
    
    In 2 places, instead of changing the printf specifier
    the type of the variable was changed to int, as that
    was what the code really exepected.
    And while at it, two internal function have been made static.

----

    Fix overflow warning for 64bit builds
    
    Fix the following build warning:
    
    ap_drv_ops.c:272:41: warning: overflow in conversion from
    ‘long unsigned int’ to ‘int’ changes value from ‘18446744073709551614’
    to ‘-2’ [-Woverflow]
      272 |                                      0, ~WPA_STA_AUTHORIZED);
    

Partial fix for
https://github.com/zephyrproject-rtos/zephyr/issues/80437