### PR TITLE
zephyr: cert: Add blob element to support parse cert data by blob

### DIFF
--- a/src/ap/ap_config.h
+++ b/src/ap/ap_config.h
@@ -407,9 +407,15 @@ struct hostapd_bss_config {
 	int ctrl_interface_gid_set;
 
 	char *ca_cert;
+	const u8 *ca_cert_blob;
+	size_t ca_cert_blob_len;
 	char *server_cert;
+	const u8 *server_cert_blob;
+	size_t server_cert_blob_len;
 	char *server_cert2;
 	char *private_key;
+	const u8 *private_key_blob;
+	size_t private_key_blob_len;
 	char *private_key2;
 	char *private_key_passwd;
 	char *private_key_passwd2;
@@ -424,6 +430,8 @@ struct hostapd_bss_config {
 	char *ocsp_stapling_response;
 	char *ocsp_stapling_response_multi;
 	char *dh_file;
+	const u8 *dh_blob;
+	size_t dh_blob_len;
 	char *openssl_ciphers;
 	char *openssl_ecdh_curves;
 	u8 *pac_opaque_encr_key;

--- a/src/ap/authsrv.c
+++ b/src/ap/authsrv.c
@@ -231,8 +231,8 @@ int authsrv_init(struct hostapd_data *hapd)
 {
 #ifdef EAP_TLS_FUNCS
 	if (hapd->conf->eap_server &&
-	    (hapd->conf->ca_cert || hapd->conf->server_cert ||
-	     hapd->conf->private_key || hapd->conf->dh_file ||
+	    (hapd->conf->ca_cert || hapd->conf->ca_cert_blob || hapd->conf->server_cert || hapd->conf->server_cert_blob ||
+	     hapd->conf->private_key || hapd->conf->private_key_blob || hapd->conf->dh_file ||
 	     hapd->conf->server_cert2 || hapd->conf->private_key2)) {
 		struct tls_config conf;
 		struct tls_connection_params params;
@@ -261,13 +261,21 @@ int authsrv_init(struct hostapd_data *hapd)
 
 		os_memset(&params, 0, sizeof(params));
 		params.ca_cert = hapd->conf->ca_cert;
+		params.ca_cert_blob = hapd->conf->ca_cert_blob;
+		params.ca_cert_blob_len = hapd->conf->ca_cert_blob_len;
 		params.client_cert = hapd->conf->server_cert;
+		params.client_cert_blob = hapd->conf->server_cert_blob;
+		params.client_cert_blob_len = hapd->conf->server_cert_blob_len;
 		params.client_cert2 = hapd->conf->server_cert2;
 		params.private_key = hapd->conf->private_key;
+		params.private_key_blob = hapd->conf->private_key_blob;
+		params.private_key_blob_len = hapd->conf->private_key_blob_len;
 		params.private_key2 = hapd->conf->private_key2;
 		params.private_key_passwd = hapd->conf->private_key_passwd;
 		params.private_key_passwd2 = hapd->conf->private_key_passwd2;
 		params.dh_file = hapd->conf->dh_file;
+		params.dh_blob = hapd->conf->dh_blob;
+		params.dh_blob_len = hapd->conf->dh_blob_len;
 		params.openssl_ciphers = hapd->conf->openssl_ciphers;
 		params.openssl_ecdh_curves = hapd->conf->openssl_ecdh_curves;
 		params.ocsp_stapling_response =


### PR DESCRIPTION
As we do not have file system support, add cert blob element
to allow parse cert data by blob instead of file for SAP.