### PR TITLE
Fix ECSA warning log and current_mode is not correct.

### DIFF
--- a/src/ap/drv_callbacks.c
+++ b/src/ap/drv_callbacks.c
@@ -911,6 +911,12 @@ void hostapd_event_ch_switch(struct hostapd_data *hapd, int freq, int ht,
 		break;
 	}
 
+	/* The operating channel changed when CSA finished, so need to update
+	 * hw_mode for all following operations to cover the cases where the
+	 * driver changed the operating band. */
+	if (finished && hostapd_csa_update_hwmode(hapd->iface))
+		return;
+
 	switch (hapd->iface->current_mode->mode) {
 	case HOSTAPD_MODE_IEEE80211A:
 		if (cf1 == 5935)

--- a/src/ap/hostapd.c
+++ b/src/ap/hostapd.c
@@ -55,6 +55,7 @@
 #include "hs20.h"
 #include "airtime_policy.h"
 #include "wpa_auth_kay.h"
+#include "hw_features.h"
 #ifdef __ZEPHYR__
 #include <supp_events.h>
 #endif /* __ZEPHYR__ */
@@ -3451,6 +3452,7 @@ static int hostapd_change_config_freq(struct hostapd_data *hapd,
 	if (!channel)
 		return -1;
 
+	hostapd_determine_mode(hapd->iface);
 	mode = hapd->iface->current_mode;
 
 	/* if a pointer to old_params is provided we save previous state */

--- a/src/ap/hw_features.c
+++ b/src/ap/hw_features.c
@@ -953,7 +953,7 @@ static int hostapd_is_usable_chans(struct hostapd_iface *iface)
 }
 
 
-static void hostapd_determine_mode(struct hostapd_iface *iface)
+void hostapd_determine_mode(struct hostapd_iface *iface)
 {
 	int i;
 	enum hostapd_hw_mode target_mode;

--- a/src/ap/hw_features.c
+++ b/src/ap/hw_features.c
@@ -953,14 +953,14 @@ static int hostapd_is_usable_chans(struct hostapd_iface *iface)
 }
 
 
-void hostapd_determine_mode(struct hostapd_iface *iface)
+int hostapd_determine_mode(struct hostapd_iface *iface)
 {
 	int i;
 	enum hostapd_hw_mode target_mode;
 
 	if (iface->current_mode ||
 	    iface->conf->hw_mode != HOSTAPD_MODE_IEEE80211ANY)
-		return;
+		return 0;
 
 	if (iface->freq < 4000)
 		target_mode = HOSTAPD_MODE_IEEE80211G;
@@ -980,8 +980,11 @@ void hostapd_determine_mode(struct hostapd_iface *iface)
 		}
 	}
 
-	if (!iface->current_mode)
-		wpa_printf(MSG_ERROR, "ACS: Cannot decide mode");
+	if (!iface->current_mode) {
+		wpa_printf(MSG_ERROR, "ACS/CSA: Cannot decide mode");
+		return -1;
+	}
+	return 0;
 }
 
 
@@ -1082,6 +1085,25 @@ int hostapd_acs_completed(struct hostapd_iface *iface, int err)
 	ret = 0;
 out:
 	return hostapd_setup_interface_complete(iface, ret);
+}
+
+
+/**
+ * hostapd_csa_update_hwmode - Update hardware mode
+ * @iface: Pointer to interface data.
+ * Returns: 0 on success, < 0 on failure
+ *
+ * Update hardware mode when the operating channel changed because of CSA.
+ */
+int hostapd_csa_update_hwmode(struct hostapd_iface *iface)
+{
+	if (!iface || !iface->conf)
+		return -1;
+
+	iface->current_mode = NULL;
+	iface->conf->hw_mode = HOSTAPD_MODE_IEEE80211ANY;
+
+	return hostapd_determine_mode(iface);
 }
 
 

--- a/src/ap/hw_features.h
+++ b/src/ap/hw_features.h
@@ -28,6 +28,7 @@ int hostapd_prepare_rates(struct hostapd_iface *iface,
 void hostapd_stop_setup_timers(struct hostapd_iface *iface);
 int hostapd_hw_skip_mode(struct hostapd_iface *iface,
 			 struct hostapd_hw_modes *mode);
+void hostapd_determine_mode(struct hostapd_iface *iface);
 #else /* NEED_AP_MLME */
 static inline void
 hostapd_free_hw_features(struct hostapd_hw_modes *hw_features,
@@ -89,6 +90,10 @@ static inline int hostapd_hw_skip_mode(struct hostapd_iface *iface,
 static inline int hostapd_check_he_6ghz_capab(struct hostapd_iface *iface)
 {
 	return 0;
+}
+
+static inline void hostapd_determine_mode(struct hostapd_iface *iface)
+{
 }
 
 #endif /* NEED_AP_MLME */

--- a/src/ap/hw_features.h
+++ b/src/ap/hw_features.h
@@ -15,6 +15,7 @@
 void hostapd_free_hw_features(struct hostapd_hw_modes *hw_features,
 			      size_t num_hw_features);
 int hostapd_get_hw_features(struct hostapd_iface *iface);
+int hostapd_csa_update_hwmode(struct hostapd_iface *iface);
 int hostapd_acs_completed(struct hostapd_iface *iface, int err);
 int hostapd_select_hw_mode(struct hostapd_iface *iface);
 const char * hostapd_hw_mode_txt(int mode);
@@ -28,7 +29,7 @@ int hostapd_prepare_rates(struct hostapd_iface *iface,
 void hostapd_stop_setup_timers(struct hostapd_iface *iface);
 int hostapd_hw_skip_mode(struct hostapd_iface *iface,
 			 struct hostapd_hw_modes *mode);
-void hostapd_determine_mode(struct hostapd_iface *iface);
+int hostapd_determine_mode(struct hostapd_iface *iface);
 #else /* NEED_AP_MLME */
 static inline void
 hostapd_free_hw_features(struct hostapd_hw_modes *hw_features,
@@ -39,6 +40,11 @@ hostapd_free_hw_features(struct hostapd_hw_modes *hw_features,
 static inline int hostapd_get_hw_features(struct hostapd_iface *iface)
 {
 	return -1;
+}
+
+static inline int hostapd_csa_update_hwmode(struct hostapd_iface *iface)
+{
+	return 0;
 }
 
 static inline int hostapd_acs_completed(struct hostapd_iface *iface, int err)
@@ -92,8 +98,9 @@ static inline int hostapd_check_he_6ghz_capab(struct hostapd_iface *iface)
 	return 0;
 }
 
-static inline void hostapd_determine_mode(struct hostapd_iface *iface)
+static inline int hostapd_determine_mode(struct hostapd_iface *iface)
 {
+	return 0;
 }
 
 #endif /* NEED_AP_MLME */


### PR DESCRIPTION
Warning prints "<wrn> wpa_supp: Failed to check if DFS is required; ret=-1" are seen during SAP switch to 2.4G's channel using ECSA CMD when SAP started on 5G channels first. The root cause is that when SAP switch to 2.4G, its iface->current_mode is still about 5G, not updated. Check the upstream hostap code, there is already related fix, so porting it here.
fix: https://github.com/zephyrproject-rtos/zephyr/issues/81123