### PR TITLE
[noup] zephyr: Add support for fetch current TX rate

### DIFF
--- a/wpa_supplicant/wpa_cli_zephyr.c
+++ b/wpa_supplicant/wpa_cli_zephyr.c
@@ -466,7 +466,7 @@ int z_wpa_ctrl_signal_poll(struct signal_poll_resp *resp)
 		return ret;
 	}
 
-	ret = sscanf((const char *)buf, "RSSI=%d", &resp->rssi);
+	ret = sscanf((const char *)buf, "RSSI=%d\nLINKSPEED=%d\n", &resp->rssi, &resp->current_txrate);
 	if (ret < 0) {
 		wpa_printf(MSG_INFO, "Failed to parse SIGNAL_POLL response: %s",
 			strerror(errno));

--- a/wpa_supplicant/wpa_cli_zephyr.h
+++ b/wpa_supplicant/wpa_cli_zephyr.h
@@ -18,6 +18,7 @@ struct add_network_resp {
 
 struct signal_poll_resp {
 	int rssi;
+	int current_txrate;
 };
 
 struct status_resp {


### PR DESCRIPTION
This is needed for Matter applications as specific by the Spec, it just says PHY rate, but Linux and other implementations only use TX rate.