### PR TITLE
[toup] mbedtls: Fix for WPA3 enterprise suiteb192 rsa3k

### DIFF
--- a/src/crypto/tls_mbedtls_alt.c
+++ b/src/crypto/tls_mbedtls_alt.c
@@ -1724,7 +1724,11 @@ static int tls_mbedtls_set_params(struct tls_conf *tls_conf, const struct tls_co
     int ret = mbedtls_ssl_config_defaults(
         &tls_conf->conf, tls_ctx_global.tls_conf ? MBEDTLS_SSL_IS_SERVER : MBEDTLS_SSL_IS_CLIENT,
         MBEDTLS_SSL_TRANSPORT_STREAM,
-        (tls_conf->flags & TLS_CONN_SUITEB) ? MBEDTLS_SSL_PRESET_SUITEB : MBEDTLS_SSL_PRESET_DEFAULT);
+        /* TODO:
+         * Technically suiteb192 rsa3k is wrong, it should be CNSA-RSA3K.
+         * A proper way would be:
+         * introduce a new preset CNSA and add RSA3K in MbedTLS. */
+        MBEDTLS_SSL_PRESET_DEFAULT);
     if (ret != 0)
     {
         elog(ret, "mbedtls_ssl_config_defaults");


### PR DESCRIPTION
Fix for WPA3 enterprise suiteb192 rsa3k connect fail.

Let default config not use MBEDTLS_SSL_PRESET_SUITEB as input mbedtls_ssl_config_defaults().
For rsa3k case has TLS_CONN_SUITEB flag and will
choose MBEDTLS_SSL_PRESET_SUITEB as input.
Then the signature algorithm will set to
ssl_tls12_preset_suiteb_sig_algs which removed rsa. Then will cause EAP Hello packet not include rsa in sig_alg and AP will return EAP failure.
Use MBEDTLS_SSL_PRESET_DEFAULT as input.