### PR TITLE
wifi: hostap: Check dev_ops pointer before using

### DIFF
--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -1215,7 +1215,7 @@ static void *wpa_drv_zep_init(void *ctx,
 	if_ctx->drv_ctx = global_priv;
 
 	dev_ops = get_dev_ops(if_ctx->dev_ctx);
-	if (!dev_ops->init) {
+	if ((!dev_ops) || (!dev_ops->init)) {
 		wpa_printf(MSG_ERROR,
 			   "%s: No op registered for init",
 			   __func__);


### PR DESCRIPTION
If the WiFi device driver does not support the supplicant API, check for a null pointer before calling the init function.

Fixes #82938
