### PR TITLE
module: add security info to module.yml

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,7 @@
 build:
   cmake-ext: True
   kconfig-ext: True
+security:
+  external-references:
+    - cpe:2.3:a:w1.fi:hostapd:2.11:*:*:*:*:*:*:*
+    - pkg:generic/hostap@hostap_2_11?vcs_url=git://w1.fi/hostap.git


### PR DESCRIPTION
Add CPE and PURL references to module.yml for for use by Zephyr's SPDX generation tool.

See github issue in Zephyr repo: https://github.com/zephyrproject-rtos/zephyr/issues/53479

I *think* the PURL is about right based on the "generic" examples in here: https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst but happy to update if there are any better suggestions.