### PR TITLE
Fix/dpp wpa msg fail

### DIFF
--- a/hostapd/ctrl_iface_zephyr.h
+++ b/hostapd/ctrl_iface_zephyr.h
@@ -20,9 +20,4 @@
 
 #define MAX_CTRL_MSG_LEN 1024
 
-struct conn_msg {
-	int msg_len;
-	char msg[MAX_CTRL_MSG_LEN];
-};
-
 void hostapd_ctrl_iface_receive(int sock, void *eloop_ctx, void *sock_ctx);

--- a/hostapd/hostapd_cli_zephyr.c
+++ b/hostapd/hostapd_cli_zephyr.c
@@ -351,30 +351,6 @@ static void hostapd_cli_close_connection(struct hostapd_data *hapd)
 	hapd_mon_sockpair[1] = -1;
 }
 
-void hostapd_msg_send(void *hapd, int level,
-		      enum wpa_msg_type type,
-		      const char *buf, size_t len)
-{
-	struct conn_msg msg;
-
-	if (len > MAX_CTRL_MSG_LEN)
-	{
-		wpa_printf(MSG_ERROR, "CTRL_MSG too long");
-		return;
-	}
-
-	if (type == WPA_MSG_PER_INTERFACE && level >= MSG_INFO &&
-	    hapd_mon_sockpair[1] > 0) {
-		memcpy(&msg.msg, buf, len);
-		msg.msg_len = len;
-		if (send(hapd_mon_sockpair[1], &msg, len + 4, 0) < 0) {
-			wpa_printf(MSG_ERROR,
-				   "sendto(hostapd monitor sock): %s",
-				   strerror(errno));
-		}
-	}
-}
-
 int zephyr_hostapd_ctrl_init(void *ctx)
 {
 	int ret;

--- a/hostapd/hostapd_cli_zephyr.c
+++ b/hostapd/hostapd_cli_zephyr.c
@@ -19,7 +19,6 @@
 #include "common/version.h"
 #include "common/ieee802_11_defs.h"
 #include "supp_main.h"
-#include "supp_events.h"
 #include "ctrl_iface_zephyr.h"
 #include "hostapd_cli_zephyr.h"
 
@@ -28,9 +27,7 @@
 #define MAX_ARGS 32
 
 int hapd_sockpair[2];
-int hapd_mon_sockpair[2];
 struct wpa_ctrl *hapd_ctrl_conn = NULL;
-struct wpa_ctrl *hapd_mon_conn = NULL;
 
 static inline uint16_t supp_strlen(const char *str)
 {
@@ -247,57 +244,8 @@ int zephyr_hostapd_cli_cmd_v(const char *fmt, ...)
 	return zephyr_hostapd_ctrl_zephyr_cmd(argc, argv);
 }
 
-static void hostapd_cli_recv_pending(struct wpa_ctrl *ctrl, struct hostapd_data *hapd)
-{
-	while (wpa_ctrl_pending(ctrl) > 0) {
-		char buf[sizeof(struct conn_msg)];
-		size_t hlen = sizeof(int);
-		size_t plen = MAX_CTRL_MSG_LEN;
-
-		if (wpa_ctrl_recv(ctrl, buf, &hlen) == 0 &&
-		    hlen == sizeof(int)) {
-			plen = *((int *)buf);
-		} else {
-			wpa_printf(MSG_ERROR, "Could not read pending message header len %d.\n", hlen);
-			continue;
-		}
-
-		if (wpa_ctrl_recv(ctrl, buf + sizeof(int), &plen) == 0) {
-			struct conn_msg *msg = (struct conn_msg *)buf;
-
-			msg->msg[msg->msg_len] = '\0';
-			wpa_printf(MSG_DEBUG, "Received len: %d, msg_len:%d - %s->END\n",
-				   plen, msg->msg_len, msg->msg);
-			if (msg->msg_len >= MAX_CTRL_MSG_LEN) {
-				wpa_printf(MSG_DEBUG, "Too long message received.\n");
-				continue;
-			}
-
-			if (msg->msg_len > 0) {
-#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP
-				if (strncmp(msg->msg, "DPP", 3) == 0) {
-					hostapd_handle_dpp_event(hapd, msg->msg, msg->msg_len);
-				}
-#endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP */
-			}
-		} else {
-			wpa_printf(MSG_INFO, "Could not read pending message.\n");
-		}
-	}
-}
-
-static void hostapd_cli_mon_receive(int sock, void *eloop_ctx,
-				    void *sock_ctx)
-{
-	struct hostapd_data *hapd = (struct hostapd_data *)eloop_ctx;
-
-	hostapd_cli_recv_pending(hapd_mon_conn, hapd);
-}
-
 static int hostapd_cli_open_connection(struct hostapd_data *hapd)
 {
-	int ret;
-
 	if (!hapd_ctrl_conn) {
 		hapd_ctrl_conn = wpa_ctrl_open(hapd_sockpair[0]);
 		if (hapd_ctrl_conn == NULL) {
@@ -307,25 +255,7 @@ static int hostapd_cli_open_connection(struct hostapd_data *hapd)
 		}
 	}
 
-	if (!hapd_mon_conn) {
-		ret = socketpair(AF_UNIX, SOCK_STREAM, 0, hapd_mon_sockpair);
-		if (ret != 0) {
-			wpa_printf(MSG_ERROR, "Failed to open monitor connection: %s",
-				   strerror(errno));
-			goto fail;
-		}
-
-		hapd_mon_conn = wpa_ctrl_open(hapd_mon_sockpair[0]);
-		if (hapd_mon_conn) {
-			eloop_register_read_sock(hapd_mon_sockpair[0],
-						 hostapd_cli_mon_receive, hapd, NULL);
-		}
-	}
-
 	return 0;
-fail:
-	wpa_ctrl_close(hapd_ctrl_conn);
-	return -1;
 }
 
 static void hostapd_cli_close_connection(struct hostapd_data *hapd)
@@ -342,13 +272,6 @@ static void hostapd_cli_close_connection(struct hostapd_data *hapd)
 	}
 	wpa_ctrl_close(hapd_ctrl_conn);
 	hapd_ctrl_conn = NULL;
-
-	eloop_unregister_read_sock(hapd_mon_sockpair[0]);
-	wpa_ctrl_close(hapd_mon_conn);
-	hapd_mon_conn = NULL;
-
-	close(hapd_mon_sockpair[1]);
-	hapd_mon_sockpair[1] = -1;
 }
 
 int zephyr_hostapd_ctrl_init(void *ctx)

--- a/wpa_supplicant/ctrl_iface_zephyr.c
+++ b/wpa_supplicant/ctrl_iface_zephyr.c
@@ -372,12 +372,3 @@ wpa_supplicant_global_ctrl_iface_deinit(struct ctrl_iface_global_priv *priv)
 
 	os_free(priv);
 }
-
-#ifdef CONFIG_WIFI_NM_HOSTAPD_AP
-void wpa_supplicant_msg_send(void *ctx, int level,
-			     enum wpa_msg_type type,
-			     const char *txt, size_t len)
-{
-	wpa_supplicant_ctrl_iface_msg_cb(ctx, level, type, txt, len);
-}
-#endif

--- a/wpa_supplicant/ctrl_iface_zephyr.c
+++ b/wpa_supplicant/ctrl_iface_zephyr.c
@@ -8,119 +8,6 @@
 
 #include "ctrl_iface_zephyr.h"
 
-
-static int wpa_supplicant_ctrl_mon_iface_attach(struct wpa_ctrl_mon **head, int sock)
-{
-	struct wpa_ctrl_mon *dst;
-
-	dst = os_zalloc(sizeof(*dst));
-	if (dst == NULL)
-		return -1;
-
-	dst->sock = sock;
-	dst->debug_level = MSG_INFO;
-	dst->next = *head;
-	*head = dst;
-	return 0;
-}
-
-
-static int wpa_supplicant_ctrl_mon_iface_detach(struct wpa_ctrl_mon **head, int sock)
-{
-	struct wpa_ctrl_mon *dst, *prev = NULL;
-
-	dst = *head;
-	while (dst) {
-		if (dst->sock == sock) {
-			if (prev == NULL) {
-				*head = dst->next;
-			} else {
-				prev->next = dst->next;
-			}
-			os_free(dst);
-			return 0;
-		}
-		prev = dst;
-		dst = dst->next;
-	}
-	return -1;
-}
-
-static void wpa_supplicant_ctrl_iface_send(struct wpa_supplicant *wpa_s,
-					   const char *ifname, int sock,
-					   struct wpa_ctrl_mon **head,
-					   int level, const char *buf,
-					   size_t len)
-{
-	struct wpa_ctrl_mon *dst, *next;
-	char levelstr[64];
-	int idx;
-	struct conn_msg msg;
-
-	dst = *head;
-	if (sock < 0 || dst == NULL)
-		return;
-
-	if (ifname)
-		os_snprintf(levelstr, sizeof(levelstr), "IFNAME=%s <%d>",
-			    ifname, level);
-	else
-		os_snprintf(levelstr, sizeof(levelstr), "<%d>", level);
-
-	idx = 0;
-	if (len > MAX_CTRL_MSG_LEN) {
-		wpa_printf(MSG_DEBUG, "CTRL_MSG too long");
-		return;
-	}
-
-	while (dst) {
-		next = dst->next;
-		if (level >= dst->debug_level) {
-			memcpy(&msg.msg, buf, len);
-			msg.msg_len = len;
-			if (send(dst->sock, &msg, len + 4, 0) < 0) {
-				wpa_printf(MSG_ERROR,
-					   "sendto(CTRL_IFACE monitor): %s",
-					   strerror(errno));
-				dst->errors++;
-			} else {
-				dst->errors = 0;
-			}
-		}
-		idx++;
-		dst = next;
-	}
-}
-
-static void wpa_supplicant_ctrl_iface_msg_cb(void *ctx, int level,
-					     enum wpa_msg_type type,
-					     const char *txt, size_t len)
-{
-	struct wpa_supplicant *wpa_s = ctx;
-
-	if (!wpa_s)
-		return;
-
-	if (type != WPA_MSG_NO_GLOBAL && wpa_s->global->ctrl_iface) {
-		struct ctrl_iface_global_priv *priv = wpa_s->global->ctrl_iface;
-
-		if (priv->ctrl_dst) {
-			wpa_supplicant_ctrl_iface_send(wpa_s, type != WPA_MSG_PER_INTERFACE ?
-							NULL : wpa_s->ifname,
-							priv->sock_pair[0],
-							 &priv->ctrl_dst, level, txt, len);
-		}
-	}
-
-	if (type == WPA_MSG_ONLY_GLOBAL || !wpa_s->ctrl_iface)
-		return;
-
-	wpa_supplicant_ctrl_iface_send(wpa_s, NULL, wpa_s->ctrl_iface->sock_pair[0],
-				       &wpa_s->ctrl_iface->ctrl_dst,
-				       level, txt, len);
-}
-
-
 static void wpa_supplicant_ctrl_iface_receive(int sock, void *eloop_ctx,
 					      void *sock_ctx)
 {
@@ -155,27 +42,8 @@ static void wpa_supplicant_ctrl_iface_receive(int sock, void *eloop_ctx,
 	while (*pos == ' ')
 		pos++;
 
-	if (os_strcmp(pos, "ATTACH") == 0) {
-		if (wpa_supplicant_ctrl_mon_iface_attach(&wpa_s->ctrl_iface->ctrl_dst,
-						    wpa_s->ctrl_iface->mon_sock_pair[1])){
-			reply_len = 1;
-		}
-		else {
-			reply_len = 2;
-		}
-	} else if (os_strcmp(pos, "DETACH") == 0) {
-		if (wpa_supplicant_ctrl_mon_iface_detach(&wpa_s->ctrl_iface->ctrl_dst,
-						    wpa_s->ctrl_iface->mon_sock_pair[1])) {
-			reply_len = 1;
-		}
-		else {
-			reply_len = 2;
-		}
-	} else {
-		reply = wpa_supplicant_ctrl_iface_process(wpa_s, pos,
-							&reply_len);
-	}
-
+	reply = wpa_supplicant_ctrl_iface_process(wpa_s, pos,
+						  &reply_len);
 	if (reply) {
 		send(sock, reply, reply_len, 0);
 	} else if (reply_len == 1) {
@@ -216,8 +84,6 @@ wpa_supplicant_ctrl_iface_init(struct wpa_supplicant *wpa_s)
 
 	eloop_register_read_sock(priv->sock_pair[1], wpa_supplicant_ctrl_iface_receive,
 				 wpa_s, priv);
-
-	wpa_msg_register_cb(wpa_supplicant_ctrl_iface_msg_cb);
 
 	return priv;
 
@@ -287,27 +153,8 @@ static void wpa_supplicant_global_ctrl_iface_receive(int sock, void *eloop_ctx,
 	while (*pos == ' ')
 		pos++;
 
-	if (os_strcmp(pos, "ATTACH") == 0) {
-		if (wpa_supplicant_ctrl_mon_iface_attach(&global->ctrl_iface->ctrl_dst,
-						    global->ctrl_iface->mon_sock_pair[1])) {
-			reply_len = 1;
-		}
-		else {
-			reply_len = 2;
-		}
-	} else if (os_strcmp(pos, "DETACH") == 0) {
-		if (wpa_supplicant_ctrl_mon_iface_detach(&global->ctrl_iface->ctrl_dst,
-						    global->ctrl_iface->mon_sock_pair[1])) {
-			reply_len = 1;
-		}
-		else {
-			reply_len = 2;
-		}
-	} else {
 	reply = wpa_supplicant_global_ctrl_iface_process(global, pos,
-							&reply_len);
-	}
-
+							 &reply_len);
 	if (reply) {
 		send(sock, reply, reply_len, 0);
 	} else if (reply_len == 1) {

--- a/wpa_supplicant/ctrl_iface_zephyr.h
+++ b/wpa_supplicant/ctrl_iface_zephyr.h
@@ -16,37 +16,14 @@
 #include "ctrl_iface.h"
 #include "common/wpa_ctrl.h"
 
-#define MAX_CTRL_MSG_LEN 256
-/**
- * struct wpa_ctrl_mon - Data structure of control interface monitors
- *
- * This structure is used to store information about registered control
- * interface monitors into struct wpa_supplicant.
- */
-struct wpa_ctrl_mon {
-	struct wpa_ctrl_mon *next;
-	int sock;
-	int debug_level;
-	int errors;
-};
-
 struct ctrl_iface_priv {
 	struct wpa_supplicant *wpa_s;
-	/* 0 - wpa_cli, 1 - ctrl_iface */
+	/* wpa_cli command socket pair */
 	int sock_pair[2];
-	int mon_sock_pair[2];
-	struct wpa_ctrl_mon *ctrl_dst;
 };
 
 struct ctrl_iface_global_priv {
 	struct wpa_global *global;
-	/* 0 - wpa_cli, 1 - ctrl_iface */
+	/* wpa_cli command socket pair */
 	int sock_pair[2];
-	int mon_sock_pair[2];
-	struct wpa_ctrl_mon *ctrl_dst;
-};
-
-struct conn_msg {
-	int msg_len;
-	char msg[MAX_CTRL_MSG_LEN];
 };


### PR DESCRIPTION
ae768f8bd621b05cdaab1893c2ece90f63135332
[noup] zephyr: remove zephyr wpas monitor socket pair
    
    The socket pair will no longer be used as we will directly filter
    and handle msg in wpa_msg_cb for zephyr.
    
    The handler path is short and quick. So it won't hold hostap task.
    Saves 4K RAM space and hostap task loops for receiving msg.

ced4ae52cd880e15128c03814686bef4f324cc86
[noup] zephyr: remove zephyr hostapd monitor socket pair
    
    The socket pair will no longer be used as we will directly filter
    and handle msg in wpa_msg_cb for zephyr.
    
    The handler path is short and quick. So it won't hold hostap task.
    Saves 4K RAM space and hostap task loops for receiving msg.

d0790ee3ebd50162d980cc4a30d60f10fae4929a
[noup] zephyr: remove zephyr wpa_msg socket send
    
    Background:
    In DPP hostapd will put more than 1K bytes text in multiple
    wpa_msg calls in one loop. This will drain hostapd monitor
    socket pair and fail. Thus DPP connection will fail.
    
    The monitor socket pair of wpa_supplicant and hostapd are not like
    ctrl_iface socket pair, which are used for sending command to
    hostap from other tasks. The monitor socket pair is used by wpa_msg
    to send messages to attatched ctrl_iface monitors. But in zephyr case,
    the monitor is hostap task itself.
    This means hostap task is both the sender and receiver task.
    So it writes all the wpa_msg text into FIFO and read it in next loop.
    So there is risk of draining socket pair FIFO and missing msg.
    And the reading socket loop can be omitted by directly handling msg
    in wpa_msg_cb.
    
    Linux uses monitor socket pair because hostap is a process and wpa_msg
    does cross-process communication.
    But zephyr hostap is used as module in the same binary with
    zephyr kernel.
    So the usage is different and we don't need to use socket pair to
    notify ctrl_iface monitors.
    As long as we don't do time-consuming process in zephyr_wpa_msg_cb,
    it won't affect hostap task.
    So the zephyr_wpa_msg_cb will only filter and restore interesting logs,
    or raise mgmt events to wifi l2 mgmt task.
    
    Fix:
    Remove socket send flow in wpa_msg.
    Directly filter and handle text in zephyr_wpa_msg_cb, coding in zephyr
    repo.