### PR TITLE
[noup] zephyr: Fix the Wi-Fi secure associations

### DIFF
--- a/src/l2_packet/l2_packet_zephyr.c
+++ b/src/l2_packet/l2_packet_zephyr.c
@@ -94,7 +94,7 @@ static void l2_packet_receive(int sock, void *eloop_ctx, void *sock_ctx)
 	// FIXME: sll_addr is not being filled as L2 header is not removed
 	hdr = (const struct ieee802_1x_hdr *) buf;
 
-	if (ll.sll_protocol != ETH_P_EAPOL) {
+	if (ntohs(ll.sll_protocol) != ETH_P_EAPOL) {
 		return;
 	}
 


### PR DESCRIPTION
Due to a recent change the Zephyr network stack sends the protocol in network byte order, so, need to be converted to host order before using it. This was dropping all EAPoL frames and broke secure association.