### PR TITLE
Zephyr: Group cipher addition in beacon

### DIFF
--- a/src/ap/wpa_auth_ie.c
+++ b/src/ap/wpa_auth_ie.c
@@ -342,7 +342,7 @@ static u8 * rsne_write_data(u8 *buf, size_t len, u8 *pos, int group,
 
 
 	if (mfp != NO_MGMT_FRAME_PROTECTION &&
-	    group_mgmt_cipher != WPA_CIPHER_AES_128_CMAC) {
+	    group_mgmt_cipher != WPA_CIPHER_NONE) {
 		if (2 + 4 > buf + len - pos)
 			return NULL;
 		if (!pmkid) {


### PR DESCRIPTION
Updated the check for group cipher addition in beacon. Due to earlier check WPA_CIPHER_AES_128_CMAC was not added in beacon.