### PR TITLE
[noup] zephyr: Remove non-existent attach/detach helper

### DIFF
--- a/src/common/wpa_ctrl.c
+++ b/src/common/wpa_ctrl.c
@@ -747,34 +747,6 @@ void wpa_ctrl_close(struct wpa_ctrl *ctrl)
 }
 #endif
 
-static int wpa_ctrl_attach_helper(struct wpa_ctrl *ctrl, int attach)
-{
-	char buf[10];
-	int ret;
-	size_t len = 10;
-
-	ret = wpa_ctrl_request(ctrl, attach ? "ATTACH" : "DETACH", 6,
-			       buf, &len, NULL);
-	if (ret < 0)
-		return ret;
-	if (len == 3 && os_memcmp(buf, "OK\n", 3) == 0)
-		return 0;
-	return -1;
-}
-
-
-int wpa_ctrl_attach(struct wpa_ctrl *ctrl)
-{
-	return wpa_ctrl_attach_helper(ctrl, 1);
-}
-
-
-int wpa_ctrl_detach(struct wpa_ctrl *ctrl)
-{
-	return wpa_ctrl_attach_helper(ctrl, 0);
-}
-
-
 #ifdef CTRL_IFACE_SOCKET
 
 int wpa_ctrl_recv(struct wpa_ctrl *ctrl, char *reply, size_t *reply_len)

--- a/wpa_supplicant/wpa_cli_zephyr.c
+++ b/wpa_supplicant/wpa_cli_zephyr.c
@@ -101,16 +101,9 @@ int zephyr_wpa_cli_cmd_resp(const char *cmd, char *resp)
 
 static void wpa_cli_close_connection(struct wpa_supplicant *wpa_s)
 {
-	int ret;
-
 	if (ctrl_conn == NULL)
 		return;
 
-	ret = wpa_ctrl_detach(ctrl_conn);
-	if (ret < 0) {
-		wpa_printf(MSG_INFO, "Failed to detach from wpa_supplicant: %s",
-			strerror(errno));
-	}
 	wpa_ctrl_close(ctrl_conn);
 	ctrl_conn = NULL;
 }


### PR DESCRIPTION
During the monitor socket rework, these are removed from the control interface but were left over in wpa_cli this causes an error message during interface down.