### PR TITLE
[noup] zephyr: Fix header file path

### DIFF
--- a/wpa_supplicant/ctrl_iface_zephyr.h
+++ b/wpa_supplicant/ctrl_iface_zephyr.h
@@ -9,7 +9,7 @@
 #include "utils/includes.h"
 
 #include "utils/common.h"
-#include "eloop.h"
+#include "utils/eloop.h"
 #include "config.h"
 #include "eapol_supp/eapol_supp_sm.h"
 #include "wpa_supplicant_i.h"


### PR DESCRIPTION
Fix header include path for eloop.h when
including ctrl_iface_zephyr.h from another module.