### PR TITLE
[noup] zephyr: Fix fractional part of Tx rate by converting to float

### DIFF
--- a/wpa_supplicant/ctrl_iface.c
+++ b/wpa_supplicant/ctrl_iface.c
@@ -8403,9 +8403,9 @@ static int wpa_supplicant_signal_poll(struct wpa_supplicant *wpa_s, char *buf,
 	pos = buf;
 	end = buf + buflen;
 
-	ret = os_snprintf(pos, end - pos, "RSSI=%d\nLINKSPEED=%lu\n"
+	ret = os_snprintf(pos, end - pos, "RSSI=%d\nLINKSPEED=%.1f\n"
 			  "NOISE=%d\nFREQUENCY=%u\n",
-			  si.data.signal, si.data.current_tx_rate / 1000,
+			  si.data.signal, (double)si.data.current_tx_rate / 1000,
 			  si.current_noise, si.frequency);
 	if (os_snprintf_error(end - pos, ret))
 		return -1;

--- a/wpa_supplicant/wpa_cli_zephyr.c
+++ b/wpa_supplicant/wpa_cli_zephyr.c
@@ -383,7 +383,7 @@ int z_wpa_ctrl_signal_poll(struct signal_poll_resp *resp)
 		return ret;
 	}
 
-	ret = sscanf((const char *)buf, "RSSI=%d\nLINKSPEED=%d\n", &resp->rssi, &resp->current_txrate);
+	ret = sscanf((const char *)buf, "RSSI=%d\nLINKSPEED=%f\n", &resp->rssi, &resp->current_txrate);
 	if (ret < 0) {
 		wpa_printf(MSG_INFO, "Failed to parse SIGNAL_POLL response: %s",
 			strerror(errno));

--- a/wpa_supplicant/wpa_cli_zephyr.h
+++ b/wpa_supplicant/wpa_cli_zephyr.h
@@ -18,7 +18,7 @@ struct add_network_resp {
 
 struct signal_poll_resp {
 	int rssi;
-	int current_txrate;
+	float current_txrate;
 };
 
 struct status_resp {


### PR DESCRIPTION
The Tx rate was divided by 1000 using integer division, which truncated the decimal part (8600 bps → 8 Mbps instead of 8.6 Mbps). This change ensures the result is stored as a float to retain precision in Mbps.