### PR TITLE
[noup] wpa_debug_zephyr: Initialize wpa_debug_show_keys from Kconfig …

### DIFF
--- a/src/utils/wpa_debug_zephyr.c
+++ b/src/utils/wpa_debug_zephyr.c
@@ -18,7 +18,7 @@
 LOG_MODULE_REGISTER(wpa_supp, CONFIG_WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL);
 
 int wpa_debug_level = MSG_INFO;
-int wpa_debug_show_keys;
+int wpa_debug_show_keys = IS_ENABLED(CONFIG_WIFI_NM_WPA_SUPPLICANT_DEBUG_SHOW_KEYS);
 int wpa_debug_timestamp;
 
 #ifndef CONFIG_NO_STDOUT_DEBUG


### PR DESCRIPTION
…option

Initialize the wpa_debug_show_keys variable based on the CONFIG_WIFI_NM_WPA_SUPPLICANT_DEBUG_SHOW_KEYS Kconfig option.

This allows compile-time control of whether key material (passwords, encryption keys, etc.) is included in debug output, equivalent to the -K command line flag in wpa_supplicant.

The option defaults to disabled for security reasons, as key material should never be logged in production systems.