### PR TITLE
[noup] hostap: Apply configured keep-alive early schedule offset

### DIFF
--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -381,6 +381,7 @@ int os_strcasecmp(const char *s1, const char *s2);
  */
 int os_strncasecmp(const char *s1, const char *s2, size_t n);
 
+#define CONFIG_KEEP_ALIVE_EARLY_MS CONFIG_WIFI_NM_WPA_SUPPLICANT_KEEP_ALIVE_EARLY_MS
 #endif
 
 

--- a/wpa_supplicant/events.c
+++ b/wpa_supplicant/events.c
@@ -2925,7 +2925,7 @@ static void wnm_bss_keep_alive(void *eloop_ctx, void *sock_ctx)
 		unsigned int msec;
 		msec = wpa_s->sme.bss_max_idle_period * 1024; /* times 1000 */
 		if (msec > 100)
-			msec -= 100;
+			msec -= CONFIG_KEEP_ALIVE_EARLY_MS;
 		eloop_register_timeout(msec / 1000, msec % 1000 * 1000,
 				       wnm_bss_keep_alive, wpa_s, NULL);
 	}
@@ -2960,7 +2960,7 @@ static void wnm_process_assoc_resp(struct wpa_supplicant *wpa_s,
 			 /* msec times 1000 */
 			msec = wpa_s->sme.bss_max_idle_period * 1024;
 			if (msec > 100)
-				msec -= 100;
+				msec -= CONFIG_KEEP_ALIVE_EARLY_MS;
 			eloop_register_timeout(msec / 1000, msec % 1000 * 1000,
 					       wnm_bss_keep_alive, wpa_s,
 					       NULL);


### PR DESCRIPTION
Use the configured value to determine the time offset (in milliseconds) for scheduling Wi-Fi keep-alive frames earlier than the BSS Max Idle Period.