### PR TITLE
[fromlist] SME: Add configurable driver processing time

### DIFF
--- a/src/drivers/driver.h
+++ b/src/drivers/driver.h
@@ -2458,6 +2458,9 @@ struct wpa_driver_capa {
 	unsigned int mbssid_max_interfaces;
 	/* Maximum profile periodicity for enhanced MBSSID advertisement */
 	unsigned int ema_max_periodicity;
+
+	/* Driver TX processing delay in microseconds, used for TX delay compensation */
+	unsigned int driver_tx_processing_delay_ms;
 };
 
 

--- a/wpa_supplicant/events.c
+++ b/wpa_supplicant/events.c
@@ -2924,8 +2924,15 @@ static void wnm_bss_keep_alive(void *eloop_ctx, void *sock_ctx)
 	if (wpa_s->sme.bss_max_idle_period) {
 		unsigned int msec;
 		msec = wpa_s->sme.bss_max_idle_period * 1024; /* times 1000 */
-		if (msec > 100)
-			msec -= 100;
+		{
+			unsigned int adj = wpa_s->driver_tx_processing_delay_ms;
+
+			/* Fallback to retain current behaviour */
+			if (adj < 100)
+				adj = 100;
+			if (msec > adj)
+				msec -= adj;
+		}
 		eloop_register_timeout(msec / 1000, msec % 1000 * 1000,
 				       wnm_bss_keep_alive, wpa_s, NULL);
 	}
@@ -2959,8 +2966,15 @@ static void wnm_process_assoc_resp(struct wpa_supplicant *wpa_s,
 			eloop_cancel_timeout(wnm_bss_keep_alive, wpa_s, NULL);
 			 /* msec times 1000 */
 			msec = wpa_s->sme.bss_max_idle_period * 1024;
-			if (msec > 100)
-				msec -= 100;
+			{
+				unsigned int adj = wpa_s->driver_tx_processing_delay_ms;
+
+				/* Fallback to retain current behaviour */
+				if (adj < 100)
+					adj = 100;
+				if (msec > adj)
+					msec -= adj;
+			}
 			eloop_register_timeout(msec / 1000, msec % 1000 * 1000,
 					       wnm_bss_keep_alive, wpa_s,
 					       NULL);

--- a/wpa_supplicant/wpa_supplicant.c
+++ b/wpa_supplicant/wpa_supplicant.c
@@ -7225,6 +7225,7 @@ static int wpa_supplicant_init_iface(struct wpa_supplicant *wpa_s,
 		    wpa_s->extended_capa_len >= 3 &&
 		    wpa_s->extended_capa[2] & 0x40)
 			wpa_s->multi_bss_support = 1;
+		wpa_s->driver_tx_processing_delay_ms = capa.driver_tx_processing_delay_ms;
 	}
 	if (wpa_s->max_remain_on_chan == 0)
 		wpa_s->max_remain_on_chan = 1000;

--- a/wpa_supplicant/wpa_supplicant_i.h
+++ b/wpa_supplicant/wpa_supplicant_i.h
@@ -1626,6 +1626,8 @@ struct wpa_supplicant {
 	u64 first_beacon_tsf;
 	unsigned int beacons_checked;
 	unsigned int next_beacon_check;
+
+	unsigned int driver_tx_processing_delay_ms;
 };
 
 


### PR DESCRIPTION
Some drivers take longer than 100ms, and there by the keepalive is sent after the keepalive period and this causes disconnections sometimes, so, adjust for the driver's processing delay (a new driver capability) and send the keepalive early (no harm in sending early).

Upstream PR: https://lists.infradead.org/pipermail/hostap/2025-July/043623.html