### PR TITLE
[noup] Fix fromtree cherry-picked for wpa_supplicant_get_scan_results

### DIFF
--- a/wpa_supplicant/wpa_supplicant.c
+++ b/wpa_supplicant/wpa_supplicant.c
@@ -883,7 +883,7 @@ void wpa_supplicant_reset_bgscan(struct wpa_supplicant *wpa_s)
 			struct wpa_scan_results *scan_res;
 			wpa_s->bgscan_ssid = wpa_s->current_ssid;
 			scan_res = wpa_supplicant_get_scan_results(wpa_s, NULL,
-								   0);
+								   0, NULL);
 			if (scan_res) {
 				bgscan_notify_scan(wpa_s, scan_res);
 				wpa_scan_results_free(scan_res);
@@ -2975,7 +2975,7 @@ void ibss_mesh_setup_freq(struct wpa_supplicant *wpa_s,
 		struct wpa_scan_results *scan_res;
 
 		scan_res = wpa_supplicant_get_scan_results(wpa_s, NULL, 0,
-								NULL);
+							   NULL);
 		if (scan_res == NULL) {
 			/* Back to HT20 */
 			freq->sec_channel_offset = 0;


### PR DESCRIPTION
An argument was missing to call wpa_supplicant_get_scan_results, fix this and fix an alignment for another call.

Original commit message from 5b4a78b1f90977fdd013baffa0a05c47ef59f817:

```
    Optimize internal BSS table updates based on a specific BSSID

    When wpa_supplicant needed to update the internal BSS table with the
    latest scan results from the driver, it fetched all BSSs and processed
    them all. This is unnecessary for cases where an update is needed only
    for a specific BSS. Optimize this by filtering out the unnecessary
    entries from the results.
```