### PR TITLE
[noup] zephyr: remove stale comment that mentions zepyr/posix/time.h

### DIFF
--- a/src/utils/os_zephyr.c
+++ b/src/utils/os_zephyr.c
@@ -8,12 +8,6 @@
 #include <time.h>
 
 #include <zephyr/posix/sys/time.h>
-
-/* The clock_gettime() would be found in <zephyr/posix/time.h> but
- * that will cause conflict with picolib definition.
- */
-int clock_gettime(clockid_t clock_id, struct timespec *ts);
-
 #include <zephyr/random/random.h>
 
 #include "includes.h"


### PR DESCRIPTION
After https://github.com/zephyrproject-rtos/zephyr/pull/96589 is merged, there is no need to declare `clock_gettime()` manually, and the stale comment that mentions `zephyr/posix/time.h` should be removed.