### PR TITLE
hostap: Declare mpi_sw_A only with EC crypto enabled

### DIFF
--- a/src/crypto/crypto_mbedtls_alt.c
+++ b/src/crypto/crypto_mbedtls_alt.c
@@ -146,11 +146,6 @@
 
 #endif /* crypto_rsa_*() */
 
-#ifdef CRYPTO_MBEDTLS_CRYPTO_BIGNUM
-#include <mbedtls/bignum.h>
-static mbedtls_mpi mpi_sw_A;
-#endif
-
 __attribute_cold__ void crypto_unload(void)
 {
     /* Nothing to do */
@@ -1999,6 +1994,9 @@ size_t crypto_ecdh_prime_len(struct crypto_ecdh *ecdh)
 #if defined(CRYPTO_MBEDTLS_CRYPTO_EC)
 
 #include <mbedtls/ecp.h>
+
+/* MPI buffer for crypto_ec_get_a() return value; not thread-safe. */
+static mbedtls_mpi mpi_sw_A;
 
 struct crypto_ec *crypto_ec_init(int group)
 {


### PR DESCRIPTION
CRYPTO_MBEDTLS_CRYPTO_BIGNUM is always defined for this translation unit, but mpi_sw_A is only referenced from crypto_ec_get_a(), which lives under CRYPTO_MBEDTLS_CRYPTO_EC. That macro follows CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3 (and DPP, SAE-PK, EAP-PWD), not the generic WPA3-available symbol.

When a product Kconfig selects the external WPA3 implementation (so internal SAE and CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3 stay off) while still building the mbedTLS PSA crypto alt, the EC section is omitted and the file-scope MPI triggered -Wunused-variable.

Define mpi_sw_A next to the EC helpers so it is compiled only when used.

Signed-off-by: Chaitanya Tata <Chaitanya.Tata@nordicsemi.no>

Assisted-by: Cursor: Auto