### PR TITLE
[noup] mbedtls: Erase CN_MISMATCH error flag set by MbedTLS library

### DIFF
--- a/src/crypto/tls_mbedtls_alt.c
+++ b/src/crypto/tls_mbedtls_alt.c
@@ -2861,6 +2861,11 @@ static int tls_mbedtls_verify_cb(void *arg, mbedtls_x509_crt *crt, int depth, ui
     struct tls_conf *tls_conf   = conn->tls_conf;
     uint32_t flags_in           = *flags;
 
+    /* Clear the MBEDTLS_X509_BADCERT_CN_MISMATCH flag (0x4) to allow
+     * custom certificate verification logic to be applied */
+    if (*flags & MBEDTLS_X509_BADCERT_CN_MISMATCH)
+	    *flags &= ~MBEDTLS_X509_BADCERT_CN_MISMATCH;
+
 #if defined(TLS_MBEDTLS_CERT_DISABLE_KEY_USAGE_CHECK)
     crt->MBEDTLS_PRIVATE(ext_types) &= ~MBEDTLS_X509_EXT_KEY_USAGE;
     crt->MBEDTLS_PRIVATE(ext_types) &= ~MBEDTLS_X509_EXT_EXTENDED_KEY_USAGE;


### PR DESCRIPTION
The hostname checks in MbedTLS library are not apt for cases where the domain-suffix checks are configured to verify the certificates. Since hostname checks are done in supplicant as well, erase the CN_MISMATCH error, if reported by MbedTLS and let supplicant verify the hostname again.

Fixes issue#88697.