### PR TITLE
crypto: mbedtls: Include pk.h for EC paths without ECDH

### DIFF
--- a/src/crypto/crypto_mbedtls_alt.c
+++ b/src/crypto/crypto_mbedtls_alt.c
@@ -2077,7 +2077,24 @@ size_t crypto_ecdh_prime_len(struct crypto_ecdh *ecdh)
 
 #if defined(CRYPTO_MBEDTLS_CRYPTO_EC)
 
+/*
+ * PSA-focused configuration may omit MBEDTLS_PK_PARSE_C and MBEDTLS_PK_WRITE_C;
+ * mbedtls/pk.h gates parse/write prototypes on those macros. Define them before
+ * the first include of pk.h in this translation unit if not already set.
+ */
+#if !defined(MBEDTLS_PK_PARSE_C)
+#define MBEDTLS_PK_PARSE_C
+#endif
+#if !defined(MBEDTLS_PK_WRITE_C)
+#define MBEDTLS_PK_WRITE_C
+#endif
+
 #include <mbedtls/private/ecp.h>
+#include <mbedtls/pk.h>
+
+/* tf-psa-crypto internal functions */
+psa_ecc_family_t mbedtls_ecc_group_to_psa(mbedtls_ecp_group_id grpid, size_t *bits);
+mbedtls_ecp_group_id mbedtls_ecc_group_from_psa(psa_ecc_family_t family, size_t bits);
 
 /* MPI buffer for crypto_ec_get_a() return value; not thread-safe. */
 static mbedtls_mpi mpi_sw_A;

--- a/src/crypto/crypto_mbedtls_alt.c
+++ b/src/crypto/crypto_mbedtls_alt.c
@@ -2303,9 +2303,13 @@ struct crypto_ec_point *crypto_ec_point_from_bin(struct crypto_ec *e, const u8 *
     if (TEST_FAIL())
         return NULL;
 
+#if !defined(MBEDTLS_ECP_SHORT_WEIERSTRASS_ENABLED) && !defined(MBEDTLS_ECP_MONTGOMERY_ENABLED)
+    return NULL;
+#else
     size_t len           = CRYPTO_EC_plen(e);
     mbedtls_ecp_point *p = os_malloc(sizeof(*p));
     u8 buf[1 + MBEDTLS_MPI_MAX_SIZE * 2];
+
     if (p == NULL)
         return NULL;
     mbedtls_ecp_point_init(p);
@@ -2336,6 +2340,7 @@ struct crypto_ec_point *crypto_ec_point_from_bin(struct crypto_ec *e, const u8 *
     mbedtls_ecp_point_free(p);
     os_free(p);
     return NULL;
+#endif /* MBEDTLS_ECP_SHORT_WEIERSTRASS_ENABLED || MBEDTLS_ECP_MONTGOMERY_ENABLED */
 }
 
 int crypto_ec_point_add(struct crypto_ec *e,
@@ -2346,6 +2351,9 @@ int crypto_ec_point_add(struct crypto_ec *e,
     if (TEST_FAIL())
         return -1;
 
+#if !defined(MBEDTLS_ECP_SHORT_WEIERSTRASS_ENABLED)
+    return -1;
+#else
     /* mbedtls does not provide an mbedtls_ecp_point add function */
     mbedtls_mpi one;
     mbedtls_mpi_init(&one);
@@ -2354,8 +2362,10 @@ int crypto_ec_point_add(struct crypto_ec *e,
                                          (const mbedtls_ecp_point *)a, &one, (const mbedtls_ecp_point *)b) ?
                   -1 :
                   0;
+
     mbedtls_mpi_free(&one);
     return ret;
+#endif /* MBEDTLS_ECP_SHORT_WEIERSTRASS_ENABLED */
 }
 
 int crypto_ec_point_mul(struct crypto_ec *e,


### PR DESCRIPTION
CRYPTO_MBEDTLS_CRYPTO_EC (WPA3, etc.) uses mbedtls_pk_* but mbedtls/pk.h was only included when CRYPTO_MBEDTLS_CRYPTO_ECDH or EC_DPP is set. Builds with WPA3 and WPS/P2P but without PSA_WANT_ALG_ECDH fail to compile.

Add the same pk.h setup and ECC PSA helper declarations at the start of the EC block.


Assisted-by: Cursor: Auto