### PR TITLE
crypto: mbedtls: Fix WPA3 EXT EC paths without oid.h

### DIFF
--- a/src/crypto/crypto_mbedtls_alt.c
+++ b/src/crypto/crypto_mbedtls_alt.c
@@ -94,6 +94,7 @@
 
 #if defined(EAP_PWD) || defined(EAP_SERVER_PWD) /* CONFIG_EAP_PWD=y */ \
     || defined(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3)                      /* CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3=y */ \
+    || defined(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3_COMMON)               /* WPA3 INT or EXT */ \
     || defined(CONFIG_PSA_WANT_ALG_ECDH)
 #define CRYPTO_MBEDTLS_CRYPTO_BIGNUM
 #endif /* crypto_bignum_*() */
@@ -118,7 +119,8 @@
 #endif /* crypto_ecdh_*() */
 
 #if defined(CONFIG_DPP) || defined(CONFIG_SAE_PK) || defined(EAP_PWD) \
-    || defined(EAP_SERVER_PWD) || defined(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3)
+    || defined(EAP_SERVER_PWD) || defined(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3) \
+    || defined(CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3_COMMON)
 #define CRYPTO_MBEDTLS_CRYPTO_EC
 #endif
 
@@ -2488,9 +2490,6 @@ void crypto_ec_point_debug_print(const struct crypto_ec *e, const struct crypto_
     // Fixing linking error undefined reference to `crypto_ec_point_debug_print'
 }
 #endif
-
-#include <psa/crypto.h>
-#include <mbedtls/oid.h>
 
 struct crypto_ec_key *crypto_ec_key_parse_priv(const u8 *der, size_t der_len)
 {


### PR DESCRIPTION
Enable CRYPTO_MBEDTLS_CRYPTO_EC and CRYPTO_MBEDTLS_CRYPTO_BIGNUM when WIFI_NM_WPA_SUPPLICANT_WPA3_COMMON is set so WPS/P2P builds with WPA3 implementation EXT compile the EC key helpers.

Drop redundant psa/crypto.h and mbedtls/oid.h includes before crypto_ec_key_parse_priv(); pk.h is already included at the EC block entry (PR #140) and oid.h is only needed in the CSR block.


Assisted-by: Cursor: Auto