### PR TITLE
Fix CVE 2025 24912

### DIFF
--- a/src/radius/radius_client.c
+++ b/src/radius/radius_client.c
@@ -1259,13 +1259,6 @@ static void radius_client_receive(int sock, void *eloop_ctx, void *sock_ctx)
 		       roundtrip / 100, roundtrip % 100);
 	rconf->round_trip_time = roundtrip;
 
-	/* Remove ACKed RADIUS packet from retransmit list */
-	if (prev_req)
-		prev_req->next = req->next;
-	else
-		radius->msgs = req->next;
-	radius->num_msgs--;
-
 	for (i = 0; i < num_handlers; i++) {
 		RadiusRxResult res;
 		res = handlers[i].handler(msg, req->msg, req->shared_secret,
@@ -1276,6 +1269,13 @@ static void radius_client_receive(int sock, void *eloop_ctx, void *sock_ctx)
 			radius_msg_free(msg);
 			/* fall through */
 		case RADIUS_RX_QUEUED:
+			/* Remove ACKed RADIUS packet from retransmit list */
+			if (prev_req)
+				prev_req->next = req->next;
+			else
+				radius->msgs = req->next;
+			radius->num_msgs--;
+
 			radius_client_msg_free(req);
 			return;
 		case RADIUS_RX_INVALID_AUTHENTICATOR:
@@ -1297,7 +1297,6 @@ static void radius_client_receive(int sock, void *eloop_ctx, void *sock_ctx)
 		       msg_type, hdr->code, hdr->identifier,
 		       invalid_authenticator ? " [INVALID AUTHENTICATOR]" :
 		       "");
-	radius_client_msg_free(req);
 
  fail:
 	radius_msg_free(msg);


### PR DESCRIPTION
Hello!

In one of our projects that uses the Nordic's nRF7002 chip and by extension the WiFi stack we have detected a vulnerability in this hostap repository with the [FOSSA](https://fossa.com/) tool.

The screenshot show below comes from the tool:

<details><summary>Screenshot</summary>
<p>

<img width="1178" height="1221" alt="image" src="https://github.com/user-attachments/assets/70527172-8b88-4855-89ba-28034dbd89dc" />

</p>
</details> 

The tool reports that our version of the hostap tool contains the CVE-2025-24912. More about this specific CVE can be found here: https://nvd.nist.gov/vuln/detail/CVE-2025-24912.

The NIST website references two commits that fix this issue:

* https://git.w1.fi/cgit/hostap/commit/?id=726432d7622cc0088ac353d073b59628b590ea44
* https://git.w1.fi/cgit/hostap/commit/?id=339a334551ca911187cc870f4f97ef08e11db109

I have checked our version of hostap, as well as the latest main, but it seems that this fork branched of from the upstream, before the fix commits were applied.

This PR contains those two commits, I cherry-picked them from the upstream.

What I would like to know:
1. Can this be merged into the Zephyr's fork of hostap?
2. Do the cherry-picked commits, applied to the fork, fix the same bug that was discovered in the upstream? They applied cleanly, however I don't have sufficient knowledge to confirm that.



